### PR TITLE
Removed unneeded 'await' causing error on hayhooks deploy

### DIFF
--- a/src/hayhooks/server/handlers/deploy.py
+++ b/src/hayhooks/server/handlers/deploy.py
@@ -4,4 +4,4 @@ from hayhooks.server.utils.deploy_utils import deploy_pipeline_def, PipelineDefi
 
 @app.post("/deploy")
 async def deploy(pipeline_def: PipelineDefinition):
-    return await deploy_pipeline_def(app, pipeline_def)
+    return deploy_pipeline_def(app, pipeline_def)


### PR DESCRIPTION
This fixes an error I get when running "hayhooks deploy pipeline.yml". The error is "TypeError: object dict can't be used in 'await' expression" from
 File "/hayhooks/server/handlers/deploy.py", line 7, in deploy
    return await deploy_pipeline_def(app, pipeline_def)