### PR TITLE
Fixed JSON Schema Serialization for Components

### DIFF
--- a/src/hayhooks/server/pipelines/models.py
+++ b/src/hayhooks/server/pipelines/models.py
@@ -1,6 +1,7 @@
-from hayhooks.server.utils.create_valid_type import create_valid_type
 from pandas import DataFrame
-from pydantic import BaseModel, create_model, ConfigDict
+from pydantic import BaseModel, ConfigDict, create_model
+
+from hayhooks.server.utils.create_valid_type import handle_unsupported_types
 
 
 class PipelineDefinition(BaseModel):
@@ -23,13 +24,16 @@ def get_request_model(pipeline_name: str, pipeline_inputs):
     config = ConfigDict(arbitrary_types_allowed=True)
 
     for component_name, inputs in pipeline_inputs.items():
-
         component_model = {}
         for name, typedef in inputs.items():
-            component_model[name] = (typedef["type"], typedef.get("default_value", ...))
-        request_model[component_name] = (create_model('ComponentParams', **component_model, __config__=config), ...)
+            input_type = handle_unsupported_types(typedef["type"], {DataFrame: dict})
+            component_model[name] = (
+                input_type,
+                typedef.get("default_value", ...),
+            )
+        request_model[component_name] = (create_model("ComponentParams", **component_model, __config__=config), ...)
 
-    return create_model(f'{pipeline_name.capitalize()}RunRequest', **request_model, __config__=config)
+    return create_model(f"{pipeline_name.capitalize()}RunRequest", **request_model, __config__=config)
 
 
 def get_response_model(pipeline_name: str, pipeline_outputs):
@@ -47,10 +51,10 @@ def get_response_model(pipeline_name: str, pipeline_outputs):
         component_model = {}
         for name, typedef in outputs.items():
             output_type = typedef["type"]
-            component_model[name] = (create_valid_type(output_type, { DataFrame: dict}), ...)
-        response_model[component_name] = (create_model('ComponentParams', **component_model, __config__=config), ...)
+            component_model[name] = (handle_unsupported_types(output_type, {DataFrame: dict}), ...)
+        response_model[component_name] = (create_model("ComponentParams", **component_model, __config__=config), ...)
 
-    return create_model(f'{pipeline_name.capitalize()}RunResponse', **response_model, __config__=config)
+    return create_model(f"{pipeline_name.capitalize()}RunResponse", **response_model, __config__=config)
 
 
 def convert_component_output(component_output):

--- a/src/hayhooks/server/pipelines/models.py
+++ b/src/hayhooks/server/pipelines/models.py
@@ -1,14 +1,7 @@
-from typing import get_args, get_origin, List, get_type_hints
 from hayhooks.server.utils.create_valid_type import create_valid_type
 from pandas import DataFrame
 from pydantic import BaseModel, create_model, ConfigDict
-from haystack.dataclasses import Document, ExtractedAnswer
-import json
 
-
-class HaystackDocument(BaseModel):
-    id: str
-    content: str
 
 class PipelineDefinition(BaseModel):
     name: str
@@ -62,21 +55,18 @@ def get_response_model(pipeline_name: str, pipeline_outputs):
 
 def convert_component_output(component_output):
     """
+    Converts outputs from a component as a dict so that it can be validated against response model
+
     Component output has this form:
 
     "documents":[
         {"id":"818170...", "content":"RapidAPI for Mac is a full-featured HTTP client."}
     ]
 
-    We inspect the output and convert haystack.Document into the HaystackDocument pydantic model as needed
     """
     result = {}
     for output_name, data in component_output.items():
-        # Empty containers, None values, empty strings and the likes: do nothing
-        if not data:
-            result[output_name] = data
         get_value = lambda data: data.to_dict()["init_parameters"] if hasattr(data, "to_dict") else data
-        # Output contains a list of Document
         if type(data) is list:
             result[output_name] = [get_value(d) for d in data]
         else:

--- a/src/hayhooks/server/utils/create_valid_type.py
+++ b/src/hayhooks/server/utils/create_valid_type.py
@@ -1,0 +1,32 @@
+from typing import get_type_hints, Dict, get_origin, get_args
+from typing_extensions import TypedDict
+from types import GenericAlias
+from inspect import isclass
+
+def create_valid_type(typed_object:type, invalid_types:Dict[type, type]):
+  """ 
+    Returns a new type specification, replacing invalid_types in typed_object.
+    example: replace_invalid_types(ExtractedAnswer, {DataFrame: List}]) returns 
+    a TypedDict with DataFrame types replaced with List
+  """
+  def validate_type(v):
+    child_typing = []
+    for t in get_args(v):
+      if t in invalid_types:
+        result = invalid_types[t]
+      elif isclass(t):
+        result = create_valid_type(t, invalid_types)
+      else: result = t
+      child_typing.append(result)
+    return GenericAlias(get_origin(v), tuple(child_typing))
+  if isclass(typed_object):
+    new_typing = {}
+    for k, v in get_type_hints(typed_object).items():
+      if(get_args(v) != ()):
+        new_typing[k] = validate_type(v)
+      else: new_typing[k] = v
+    if new_typing == {}:
+      return typed_object
+    else: return TypedDict(typed_object.__name__, new_typing)
+  else:
+    return validate_type(typed_object)

--- a/src/hayhooks/server/utils/create_valid_type.py
+++ b/src/hayhooks/server/utils/create_valid_type.py
@@ -4,29 +4,29 @@ from types import GenericAlias
 from inspect import isclass
 
 def create_valid_type(typed_object:type, invalid_types:Dict[type, type]):
-  """ 
-    Returns a new type specification, replacing invalid_types in typed_object.
-    example: replace_invalid_types(ExtractedAnswer, {DataFrame: List}]) returns 
-    a TypedDict with DataFrame types replaced with List
-  """
-  def validate_type(v):
-    child_typing = []
-    for t in get_args(v):
-      if t in invalid_types:
-        result = invalid_types[t]
-      elif isclass(t):
-        result = create_valid_type(t, invalid_types)
-      else: result = t
-      child_typing.append(result)
-    return GenericAlias(get_origin(v), tuple(child_typing))
-  if isclass(typed_object):
-    new_typing = {}
-    for k, v in get_type_hints(typed_object).items():
-      if(get_args(v) != ()):
-        new_typing[k] = validate_type(v)
-      else: new_typing[k] = v
-    if new_typing == {}:
-      return typed_object
-    else: return TypedDict(typed_object.__name__, new_typing)
-  else:
-    return validate_type(typed_object)
+    """ 
+        Returns a new type specification, replacing invalid_types in typed_object.
+        example: replace_invalid_types(ExtractedAnswer, {DataFrame: List}]) returns 
+        a TypedDict with DataFrame types replaced with List
+    """
+    def validate_type(v):
+        child_typing = []
+        for t in get_args(v):
+            if t in invalid_types:
+                result = invalid_types[t]
+            elif isclass(t):
+                result = create_valid_type(t, invalid_types)
+            else: result = t
+            child_typing.append(result)
+        return GenericAlias(get_origin(v), tuple(child_typing))
+    if isclass(typed_object):
+        new_typing = {}
+        for k, v in get_type_hints(typed_object).items():
+            if(get_args(v) != ()):
+                new_typing[k] = validate_type(v)
+            else: new_typing[k] = v
+        if new_typing == {}:
+            return typed_object
+        else: return TypedDict(typed_object.__name__, new_typing)
+    else:
+        return validate_type(typed_object)


### PR DESCRIPTION
Currently if you try to go to http://localhost:1416/docs#/ with an extractive pipeline, an error will be thrown because the response class, ExtractedAnswer, contains a DataFrame, which pydantic is unable to serialize. I have added a function create_valid_type that creates a new type, replacing invalid types with those specified. This also means that it is no longer necessary to convert Documents to HaystackDocument for validation by pydantic.