### PR TITLE
Enhacne the response of '/' endpoint

### DIFF
--- a/src/hayhooks/server/app.py
+++ b/src/hayhooks/server/app.py
@@ -37,7 +37,7 @@ async def root():
     return {
         "swagger_docs" : "http://localhost:1416/docs",
         "deploy_pipeline" : "http://localhost:1416/deploy",
-        "draw_pipeline" : "http://localhost:1416/draw{/pipeline_name}",
+        "draw_pipeline" : "http://localhost:1416/draw/{pipeline_name}",
         "server_status" : "http://localhost:1416/status",
-        "undeploy_pipeline" : "http://localhost:1416/undeploy{/pipeline_name}",
+        "undeploy_pipeline" : "http://localhost:1416/undeploy/{pipeline_name}",
     }

--- a/src/hayhooks/server/app.py
+++ b/src/hayhooks/server/app.py
@@ -34,4 +34,10 @@ app = create_app()
 
 @app.get("/")
 async def root():
-    return {}
+    return {
+        "swagger_docs" : "http://localhost:1416/docs",
+        "deploy_pipeline" : "http://localhost:1416/deploy",
+        "draw_pipeline" : "http://localhost:1416/draw{/pipeline_name}",
+        "server_status" : "http://localhost:1416/status",
+        "undeploy_pipeline" : "http://localhost:1416/undeploy{/pipeline_name}",
+    }


### PR DESCRIPTION
Updated response:

```json
{
      "swagger_docs" : "http://localhost:1416/docs",
      "deploy_pipeline" : "http://localhost:1416/deploy",
      "draw_pipeline" : "http://localhost:1416/draw{/pipeline_name}",
      "server_status" : "http://localhost:1416/status",
      "undeploy_pipeline" : "http://localhost:1416/undeploy{/pipeline_name}",
  }
```