### PR TITLE
Disable ssl verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ $ hayhooks undeploy test_pipeline_01
 Pipeline successfully undeployed
 ```
 
+### Set a hayhooks server
+
+To connect to a specific server you can pass a `--server` argument to the client:
+```bash
+$ hayhooks --server http://myserver:1416 status
+```
+
+#### Disable SSL verification
+
+For development purposes, you can disable SSL verification with the `--disable-ssl` flag:
+```bash
+$ hayhooks --disable-ssl status
+```
+
 ## Docker setup
 
 > [!TIP]

--- a/src/hayhooks/cli/__init__.py
+++ b/src/hayhooks/cli/__init__.py
@@ -11,10 +11,11 @@ from hayhooks.cli.undeploy import undeploy
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]}, invoke_without_command=True)
 @click.version_option(prog_name="Hayhooks")
-@click.option('--server', default="http://localhost:1416")
+@click.option('-s', '--server', default="http://localhost:1416", help="Hayhooks server URL")
+@click.option('-k', '--disable-ssl', default=False, is_flag=True, help="Disable SSL certificate verification")
 @click.pass_context
-def hayhooks(ctx, server):
-    ctx.obj = server
+def hayhooks(ctx, server, disable_ssl):
+    ctx.obj = server, disable_ssl
 
 
 hayhooks.add_command(run)

--- a/src/hayhooks/cli/deploy/__init__.py
+++ b/src/hayhooks/cli/deploy/__init__.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from urllib.parse import urljoin
 
 import click
 import requests
@@ -8,10 +9,15 @@ import requests
 @click.pass_obj
 @click.option('-n', '--name')
 @click.argument('pipeline_file', type=click.File('r'))
-def deploy(server, name, pipeline_file):
+def deploy(server_conf, name, pipeline_file):
+    server, disable_ssl = server_conf
     if name is None:
         name = Path(pipeline_file.name).stem
-    resp = requests.post(f"{server}/deploy", json={"name": name, "source_code": str(pipeline_file.read())})
+    resp = requests.post(
+        urljoin(server, "deploy"),
+        json={"name": name, "source_code": str(pipeline_file.read())}, 
+        verify=not disable_ssl
+    )
 
     if resp.status_code >= 400:
         click.echo(f"Error deploying pipeline: {resp.json().get('detail')}")

--- a/src/hayhooks/cli/status/__init__.py
+++ b/src/hayhooks/cli/status/__init__.py
@@ -1,3 +1,5 @@
+from urllib.parse import urljoin
+
 import click
 import requests
 from requests.exceptions import ConnectionError
@@ -5,9 +7,10 @@ from requests.exceptions import ConnectionError
 
 @click.command()
 @click.pass_obj
-def status(server):
+def status(server_conf):
+    server, disable_ssl = server_conf
     try:
-        r = requests.get(f"{server}/status")
+        r = requests.get(urljoin(server, "status"), verify=not disable_ssl)
     except ConnectionError:
         click.echo("Hayhooks server is not responding. To start one, run `hayooks run`")
         return

--- a/src/hayhooks/cli/undeploy/__init__.py
+++ b/src/hayhooks/cli/undeploy/__init__.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from urllib.parse import urljoin
 
 import click
 import requests
@@ -8,9 +9,10 @@ from requests import ConnectionError
 @click.command()
 @click.pass_obj
 @click.argument('pipeline_name')
-def undeploy(server, pipeline_name):
+def undeploy(server_conf, pipeline_name):
+    server, disable_ssl = server_conf
     try:
-        resp = requests.post(f"{server}/undeploy/{pipeline_name}")
+        resp = requests.post(urljoin(server, f"undeploy/{pipeline_name}"), verify=not disable_ssl)
 
         if resp.status_code >= 400:
             click.echo(f"Cannot undeploy pipeline: {resp.json().get('detail')}")


### PR DESCRIPTION
Sometimes for development purposes we need to skip ssl verification, otherwise we face the ssl verification error for unverified certificates