### PR TITLE
Renamed custom-components to custom_components

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ $ docker buildx bake
 
 There are 2 special folders in the container you can override using a `mount`:
 1. A folder `/opt/pipelines` containing pipeline definitions that will be automatically deployed when the container starts
-2. A folder `/opt/custom-components` containing custom components that Haystack will be able to import if part of a pipeline
+2. A folder `/opt/custom_components` containing custom components that Haystack will be able to import if part of a pipeline
 
 For example, you can mount a local `./pipelines` folder containing pipelines you want to run at start-up like this:
 

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -15,7 +15,7 @@ variable "PIPELINES_DIR" {
 }
 
 variable "ADDITIONAL_PYTHON_PATH" {
-  default = "/opt/custom-components"
+  default = "/opt/custom_components"
 }
 
 target "default" {


### PR DESCRIPTION
Changed `custom-components`  to `custom_components` for reasons detailed in https://github.com/deepset-ai/hayhooks/issues/28

