### PR TITLE
convert union type with none to optional

### DIFF
--- a/src/hayhooks/server/utils/create_valid_type.py
+++ b/src/hayhooks/server/utils/create_valid_type.py
@@ -1,6 +1,6 @@
 from inspect import isclass
 from types import GenericAlias
-from typing import Dict, Union, get_args, get_origin, get_type_hints
+from typing import Dict, Union, Optional, get_args, get_origin, get_type_hints
 
 from typing_extensions import TypedDict
 
@@ -36,6 +36,12 @@ def handle_unsupported_types(type_: type, types_mapping: Dict[type, type]) -> Un
             else:
                 new_type[arg_name] = arg_type
         if new_type:
+            # because TypedDict can't handle union types with None
+            # rewrite them as Optional[type]
+            for arg_name, arg_type in new_type.items():
+                type_args = get_args(arg_type)
+                if len(type_args) == 2 and type_args[1] is type(None):
+                    new_type[arg_name] = Optional[type_args[0]]
             return TypedDict(type_.__name__, new_type)
 
         return type_

--- a/src/hayhooks/server/utils/create_valid_type.py
+++ b/src/hayhooks/server/utils/create_valid_type.py
@@ -1,8 +1,6 @@
 from inspect import isclass
 from types import GenericAlias
-from typing import Dict, Union, Optional, get_args, get_origin, get_type_hints
-
-from typing_extensions import TypedDict
+from typing import Dict, Optional, Union, get_args, get_origin, get_type_hints
 
 
 def handle_unsupported_types(type_: type, types_mapping: Dict[type, type]) -> Union[GenericAlias, type]:


### PR DESCRIPTION
`TypedDict` is unable to handle `Union[type, NoneType]`, it requires the type to be `Optional[type]`. I've added a small fix for that. This fixes #25.  

Example traceback with deploying a pipeline that contains `DocumentJoiner`: 
```
Traceback (most recent call last):
...
  File "/Users/rustynail/Projects/github/hayhooks/src/hayhooks/server/__init__.py", line 1, in <module>
    from hayhooks.server.app import app
  File "/Users/rustynail/Projects/github/hayhooks/src/hayhooks/server/app.py", line 32, in <module>
    app = create_app()
  File "/Users/rustynail/Projects/github/hayhooks/src/hayhooks/server/app.py", line 27, in create_app
    deployed_pipeline = deploy_pipeline_def(app, pipeline_defintion)
  File "/Users/rustynail/Projects/github/hayhooks/src/hayhooks/server/utils/deploy_utils.py", line 20, in deploy
_pipeline_def
    PipelineRunRequest = get_request_model(pipeline_def.name, pipe.inputs())
  File "/Users/rustynail/Projects/github/hayhooks/src/hayhooks/server/pipelines/models.py", line 33, in get_requ
est_model
    raise e
  File "/Users/rustynail/Projects/github/hayhooks/src/hayhooks/server/pipelines/models.py", line 30, in get_requ
est_model
    input_type = handle_unsupported_types(typedef["type"], {DataFrame: dict})
  File "/Users/rustynail/Projects/github/hayhooks/src/hayhooks/server/utils/create_valid_type.py", line 51, in h
andle_unsupported_types
    return _handle_generics(type_)
  File "/Users/rustynail/Projects/github/hayhooks/src/hayhooks/server/utils/create_valid_type.py", line 25, in _
handle_generics
    result = handle_unsupported_types(t, types_mapping)
  File "/Users/rustynail/Projects/github/hayhooks/src/hayhooks/server/utils/create_valid_type.py", line 35, in h
andle_unsupported_types
    new_type[arg_name] = _handle_generics(arg_type)
  File "/Users/rustynail/Projects/github/hayhooks/src/hayhooks/server/utils/create_valid_type.py", line 25, in _
handle_generics
    result = handle_unsupported_types(t, types_mapping)
  File "/Users/rustynail/Projects/github/hayhooks/src/hayhooks/server/utils/create_valid_type.py", line 47, in h
andle_unsupported_types
    raise e
  File "/Users/rustynail/Projects/github/hayhooks/src/hayhooks/server/utils/create_valid_type.py", line 40, in h
andle_unsupported_types
    return TypedDict(type_.__name__, new_type)
  File "/Users/rustynail/miniconda3/envs/vlm-rag/lib/python3.10/site-packages/typing_extensions.py", line 1123, 
in TypedDict
    td = _TypedDictMeta(typename, (), ns, total=total, closed=closed)
  File "/Users/rustynail/miniconda3/envs/vlm-rag/lib/python3.10/site-packages/typing_extensions.py", line 954, i
n __new__
    own_annotations = {
  File "/Users/rustynail/miniconda3/envs/vlm-rag/lib/python3.10/site-packages/typing_extensions.py", line 955, i
n <dictcomp>
    n: typing._type_check(tp, msg, module=tp_dict.__module__)
  File "/Users/rustynail/miniconda3/envs/vlm-rag/lib/python3.10/typing.py", line 171, in _type_check
    raise TypeError(f"Plain {arg} is not valid as type argument")
TypeError: Plain typing.Union[str, NoneType] is not valid as type argument
```