### PR TITLE
Fix the Pydantic Validation Error -> convert_component_output

### DIFF
--- a/src/hayhooks/server/pipelines/models.py
+++ b/src/hayhooks/server/pipelines/models.py
@@ -60,7 +60,6 @@ def get_response_model(pipeline_name: str, pipeline_outputs):
 
     return create_model(f"{pipeline_name.capitalize()}RunResponse", **response_model, __config__=config)
 
-
 def convert_component_output(component_output):
     """
     Converts outputs from a component as a dict so that it can be validated against response model
@@ -80,10 +79,12 @@ def convert_component_output(component_output):
                 return data.to_dict()["init_parameters"]
             elif hasattr(data, "to_dict"):
                 return data.to_dict()
+            elif hasattr(data, "__dict__"):
+                return {k: v for k, v in data.__dict__.items() if not k.startswith('_')}
             else:
                 return data
 
-        if type(data) is list:
+        if isinstance(data, list):
             result[output_name] = [get_value(d) for d in data]
         else:
             result[output_name] = get_value(data)


### PR DESCRIPTION
I am currently trying to resolve the Pydantic Response error. I believe the root cause lies in the convert_component_output function, which cannot properly handle the ApiMeta. It seems the intended functionality is to treat this field as a dictionary for the model_dump. Therefore, I have enhanced the convert_component_output function, and it works successfully on my end. 

### Yml
```
components:
  generator:
    init_parameters:
      api_base_url: null
      api_key:
        env_vars:
        - OPENAI_API_KEY
        strict: true
        type: env_var
      generation_kwargs: {}
      model: gpt-4o-mini
      streaming_callback: null
      system_prompt: null
    type: haystack.components.generators.openai.OpenAIGenerator
  prompt:
    init_parameters:
      required_variables: null
      template: "\nYou will be provided some context, followed by the URL that this\
        \ context comes from.\nAnswer the question based on the context, and reference\
        \ the URL from which your answer is generated.\nYour answer should be in {{\
        \ language }}.\nContext:\n{% for doc in documents %}\n   {{ doc.content }}\
        \ \n   URL: {{ doc.meta['url']}}\n{% endfor %}\nQuestion: {{ query }}\nAnswer:\n"
      variables: null
    type: haystack.components.builders.prompt_builder.PromptBuilder
  query_embedder:
    init_parameters:
      api_base_url: null
      api_key:
        env_vars:
        - COHERE_API_KEY
        - CO_API_KEY
        strict: true
        type: env_var
      input_type: search_query
      model: embed-english-v3.0
      timeout: 120
      truncate: END
      use_async_client: false
    type: haystack_integrations.components.embedders.cohere.text_embedder.CohereTextEmbedder
  retriever:
    init_parameters:
      document_store:
        init_parameters:
          bm25_algorithm: BM25L
          bm25_parameters: {}
          bm25_tokenization_regex: (?u)\b\w\w+\b
          embedding_similarity_function: dot_product
        type: haystack.document_stores.in_memory.document_store.InMemoryDocumentStore
      filter_policy: replace
      filters: null
      return_embedding: false
      scale_score: false
      top_k: 10
    type: haystack.components.retrievers.in_memory.embedding_retriever.InMemoryEmbeddingRetriever
connections:
- receiver: retriever.query_embedding
  sender: query_embedder.embedding
- receiver: prompt.documents
  sender: retriever.documents
- receiver: generator.prompt
  sender: prompt.prompt
max_loops_allowed: 100
metadata: {}
```

### Response 
<img width="849" alt="image" src="https://github.com/user-attachments/assets/ee759cd6-7027-4dbf-a82d-37d6bc752955">

### Error Stack
```
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/uvicorn/protocols/http/h11_impl.py", line 406, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 70, in __call__
    return await self.app(scope, receive, send)
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/starlette/applications.py", line 113, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/starlette/middleware/errors.py", line 187, in __call__
    raise exc
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/starlette/middleware/errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/starlette/_exception_handler.py", line 62, in wrapped_app
    raise exc
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/starlette/_exception_handler.py", line 51, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/starlette/routing.py", line 715, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/starlette/routing.py", line 735, in app
    await route.handle(scope, receive, send)
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/starlette/routing.py", line 288, in handle
    await self.app(scope, receive, send)
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/starlette/routing.py", line 76, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/starlette/_exception_handler.py", line 62, in wrapped_app
    raise exc
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/starlette/_exception_handler.py", line 51, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/starlette/routing.py", line 73, in app
    response = await f(request)
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/fastapi/routing.py", line 301, in app
    raw_response = await run_endpoint_function(
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/fastapi/routing.py", line 212, in run_endpoint_function
    return await dependant.call(**values)
  File "/Volumes/workspace/SWorkspace/hayhooks/src/hayhooks/server/utils/deploy_utils.py", line 32, in pipeline_run
    return JSONResponse(PipelineRunResponse(**final_output).model_dump(), status_code=200)
  File "/Users/hawei/miniconda3/envs/hayhooks/lib/python3.10/site-packages/pydantic/main.py", line 209, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for StartRunResponse
query_embedder.meta
  Input should be a valid dictionary [type=dict_type, input_value=ApiMeta(api_version=ApiMe...okens=None, warnings=[]), input_type=ApiMeta]
    For further information visit https://errors.pydantic.dev/2.9/v/dict_type
```
