### PR TITLE
Handle Callable-like types in get_request_model (eg streaming_callback)

### DIFF
--- a/src/hayhooks/server/pipelines/models.py
+++ b/src/hayhooks/server/pipelines/models.py
@@ -1,5 +1,6 @@
 from pandas import DataFrame
 from pydantic import BaseModel, ConfigDict, create_model
+from typing import Callable
 
 from hayhooks.server.utils.create_valid_type import handle_unsupported_types
 
@@ -27,7 +28,7 @@ def get_request_model(pipeline_name: str, pipeline_inputs):
         component_model = {}
         for name, typedef in inputs.items():
             try:
-                input_type = handle_unsupported_types(typedef["type"], {DataFrame: dict})
+                input_type = handle_unsupported_types(typedef["type"], {DataFrame: dict, Callable: dict})
             except TypeError as e:
                 print(f"ERROR at {component_name!r}, {name}: {typedef}")
                 raise e

--- a/src/hayhooks/server/utils/create_valid_type.py
+++ b/src/hayhooks/server/utils/create_valid_type.py
@@ -1,24 +1,36 @@
+from collections.abc import Callable as CallableABC
 from inspect import isclass
 from types import GenericAlias
-from typing import Dict, Optional, Union, get_args, get_origin, get_type_hints
+from typing import Dict, Optional, Union, get_args, get_origin, get_type_hints, Callable
 
 
 def handle_unsupported_types(type_: type, types_mapping: Dict[type, type]) -> Union[GenericAlias, type]:
     """
     Recursively handle types that are not supported by Pydantic by replacing them with the given types mapping.
-
-    :param type_: Type to replace if not supported
-    :param types_mapping: Mapping of types to replace
     """
 
-    def _handle_generics(t_) -> GenericAlias:
-        """
-        Handle generics recursively
-        """
+    def is_callable_type(t):
+        """Check if a type is any form of callable"""
+        origin = get_origin(t)
+        return (
+            t is Callable
+            or origin is Callable
+            or origin is CallableABC
+            or (origin is not None and isinstance(origin, type) and issubclass(origin, CallableABC))
+            or (isinstance(t, type) and issubclass(t, CallableABC))
+        )
+
+    def handle_generics(t_) -> GenericAlias:
+        """Handle generics recursively"""
+        if is_callable_type(t_):
+            return types_mapping[Callable]
+
         child_typing = []
         for t in get_args(t_):
             if t in types_mapping:
                 result = types_mapping[t]
+            elif is_callable_type(t):
+                result = types_mapping[Callable]
             elif isclass(t):
                 result = handle_unsupported_types(t, types_mapping)
             else:
@@ -26,20 +38,19 @@ def handle_unsupported_types(type_: type, types_mapping: Dict[type, type]) -> Un
             child_typing.append(result)
 
         if len(child_typing) == 2 and child_typing[1] is type(None):
-            # because TypedDict can't handle union types with None
-            # rewrite them as Optional[type]
             return Optional[child_typing[0]]
         else:
             return GenericAlias(get_origin(t_), tuple(child_typing))
+
+    if is_callable_type(type_):
+        return types_mapping[Callable]
 
     if isclass(type_):
         new_type = {}
         for arg_name, arg_type in get_type_hints(type_).items():
             if get_args(arg_type):
-                new_type[arg_name] = _handle_generics(arg_type)
+                new_type[arg_name] = handle_generics(arg_type)
             else:
                 new_type[arg_name] = arg_type
-
         return type_
-
-    return _handle_generics(type_)
+    return handle_generics(type_)

--- a/tests/test_handle_callable_type.py
+++ b/tests/test_handle_callable_type.py
@@ -1,0 +1,32 @@
+import typing
+import haystack
+from types import NoneType
+from hayhooks.server.pipelines.models import get_request_model
+
+
+def test_handle_callable_type_when_creating_pipeline_models():
+    pipeline_name = "test_pipeline"
+    pipeline_inputs = {
+        'generator': {
+            'system_prompt': {'type': typing.Optional[str], 'is_mandatory': False, 'default_value': None},
+            'streaming_callback': {
+                'type': typing.Optional[
+                    typing.Callable[[haystack.dataclasses.streaming_chunk.StreamingChunk], NoneType]
+                ],
+                'is_mandatory': False,
+                'default_value': None,
+            },
+            'generation_kwargs': {
+                'type': typing.Optional[typing.Dict[str, typing.Any]],
+                'is_mandatory': False,
+                'default_value': None,
+            },
+        }
+    }
+
+    request_model = get_request_model(pipeline_name, pipeline_inputs)
+
+    # This line used to throw an error because the Callable type was not handled correctly
+    # by the handle_unsupported_types function
+    assert request_model.model_json_schema() is not None
+    assert request_model.__name__ == "Test_pipelineRunRequest"


### PR DESCRIPTION
This should add to `handle_unsupported_types` the `Callable` type support (which will be converted to `dict`, since it's not serializable by default by Pydantic). 

Probably not the neatest way, but should make deployment and docs work (briefly tested on https://github.com/deepset-ai/hayhooks/issues/38)