### PR TITLE
Fix Python version requirement to >=3.7,<3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "hayhooks"
 dynamic = ["version"]
 description = 'Grab and deploy Haystack pipelines'
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.7,<3.13"
 license = "Apache-2.0"
 keywords = []
 authors = [


### PR DESCRIPTION
Minor change to avoid using latest python version (which is still not fully supported by packages like `torch` or `sentence_transformers`)