### PR TITLE
Add basic action to run current tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Install Hatch
         run: pip install hatch==${{ env.HATCH_VERSION }}
 
-      - name: Run unit and integration tests
-        run: hatch run test:all
+      - name: Run tests and generate coverage report
+        run: hatch run test:cov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,6 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
       matrix:
         python-version: [3.9, 3.10.x, 3.11, 3.12]
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,5 +32,5 @@ jobs:
       - name: Install Hatch
         run: pip install hatch==${{ env.HATCH_VERSION }}
 
-      - name: Run tests
-        run: hatch run test
+      - name: Run unit and integration tests
+        run: hatch run test:all

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+env:
+  HATCH_VERSION: "1.14.0"
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9, 3.10, 3.11, 3.12]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Hatch
+        run: pip install hatch==${{ env.HATCH_VERSION }}
+
+      - name: Run tests
+        run: hatch run test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   HATCH_VERSION: "1.14.0"
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         python-version: [3.9, 3.10.x, 3.11, 3.12]
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10.x, 3.11, 3.12]
+        python-version: [3.9, '3.10', 3.11, 3.12]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12]
+        python-version: [3.9, 3.10.x, 3.11, 3.12]
     steps:
       - uses: actions/checkout@v4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "hayhooks"
 dynamic = ["version"]
 description = 'Grab and deploy Haystack pipelines'
 readme = "README.md"
-requires-python = ">=3.7,<3.13"
+requires-python = ">=3.9,<3.13"
 license = "Apache-2.0"
 keywords = []
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ cov-report = [
   "coverage report",
 ]
 cov = [
-  "test-cov",
+  "all-cov",
   "cov-report",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
   "pytest-mock",
 ]
 [tool.hatch.envs.default.scripts]
-test = "pytest {args:tests}"
+test = "pytest -vv -s {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"
 cov-report = [
   "- coverage combine",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,15 +43,9 @@ hayhooks = "hayhooks.cli:hayhooks"
 [tool.hatch.version]
 source = "vcs"
 
-[tool.hatch.envs.default]
-dependencies = [
-  "coverage[toml]>=6.5",
-  "pytest",
-  "pytest-mock",
-]
-[tool.hatch.envs.default.scripts]
-test = "pytest -vv -s {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
+[tool.hatch.envs.test.scripts]
+all = "pytest -vv {args:tests}"
+all-cov = "coverage run -m pytest {args:tests}"
 cov-report = [
   "- coverage combine",
   "coverage report",
@@ -61,8 +55,17 @@ cov = [
   "cov-report",
 ]
 
+[tool.hatch.envs.test]
+extra-dependencies = [
+  "coverage[toml]>=6.5",
+  "pytest",
+  "pytest-mock",
+  "qdrant-haystack",
+  "trafilatura",
+]
+
 [[tool.hatch.envs.all.matrix]]
-python = ["3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.lint]
 detached = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ cov = [
 ]
 
 [tool.hatch.envs.test]
-installer = "uv"
 extra-dependencies = [
   "coverage[toml]>=6.5",
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ hayhooks = "hayhooks.cli:hayhooks"
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.envs.default]
+installer = "uv"
+
 [tool.hatch.envs.test.scripts]
 all = "pytest -vv {args:tests}"
 all-cov = "coverage run -m pytest {args:tests}"
@@ -56,6 +59,7 @@ cov = [
 ]
 
 [tool.hatch.envs.test]
+installer = "uv"
 extra-dependencies = [
   "coverage[toml]>=6.5",
   "pytest",

--- a/tests/test_handle_callable_type.py
+++ b/tests/test_handle_callable_type.py
@@ -1,5 +1,4 @@
 from collections.abc import Callable as CallableABC
-from types import NoneType
 from typing import Any, Callable, Optional, Union
 
 import haystack
@@ -20,7 +19,7 @@ from hayhooks.server.utils.create_valid_type import is_callable_type
         (str, False),
         (Any, False),
         (Union[int, str], False),
-        (Optional[Callable[[haystack.dataclasses.streaming_chunk.StreamingChunk], NoneType]], True),
+        (Optional[Callable[[haystack.dataclasses.streaming_chunk.StreamingChunk], type(None)]], True),
     ],
 )
 def test_is_callable_type(t, expected):
@@ -33,7 +32,7 @@ def test_skip_callables_when_creating_pipeline_models():
         "generator": {
             "system_prompt": {"type": Optional[str], "is_mandatory": False, "default_value": None},
             "streaming_callback": {
-                "type": Optional[Callable[[haystack.dataclasses.streaming_chunk.StreamingChunk], NoneType]],
+                "type": Optional[Callable[[haystack.dataclasses.streaming_chunk.StreamingChunk], type(None)]],
                 "is_mandatory": False,
                 "default_value": None,
             },


### PR DESCRIPTION
With this I am adding a basic action to run tests on Python `3.9`-`3.12` (I've removed `3.7`-`3.8` support which was present in `pyproject.toml`).