### PR TITLE
Refactored API route handlers using APIRouter(s)

### DIFF
--- a/src/hayhooks/server/__init__.py
+++ b/src/hayhooks/server/__init__.py
@@ -1,4 +1,4 @@
 from hayhooks.server.app import app
-from hayhooks.server.handlers import *
+from hayhooks.server.routers import *
 
 __all__ = ["app"]

--- a/src/hayhooks/server/app.py
+++ b/src/hayhooks/server/app.py
@@ -3,6 +3,7 @@ import os
 import glob
 from pathlib import Path
 from hayhooks.server.utils.deploy_utils import deploy_pipeline_def, PipelineDefinition
+from hayhooks.server.routers import status_router, draw_router, deploy_router, undeploy_router
 import logging
 
 logger = logging.getLogger("uvicorn.info")
@@ -13,6 +14,12 @@ def create_app() -> FastAPI:
         app = FastAPI(root_path=root_path)
     else:
         app = FastAPI()
+
+    # Include all routers
+    app.include_router(status_router)
+    app.include_router(draw_router)
+    app.include_router(deploy_router)
+    app.include_router(undeploy_router)
 
     # Deploy all pipelines in the pipelines directory
     pipelines_dir = os.environ.get("HAYHOOKS_PIPELINES_DIR")
@@ -35,9 +42,9 @@ app = create_app()
 @app.get("/")
 async def root():
     return {
-        "swagger_docs" : "http://localhost:1416/docs",
-        "deploy_pipeline" : "http://localhost:1416/deploy",
-        "draw_pipeline" : "http://localhost:1416/draw/{pipeline_name}",
-        "server_status" : "http://localhost:1416/status",
-        "undeploy_pipeline" : "http://localhost:1416/undeploy/{pipeline_name}",
+        "swagger_docs": "http://localhost:1416/docs",
+        "deploy_pipeline": "http://localhost:1416/deploy",
+        "draw_pipeline": "http://localhost:1416/draw/{pipeline_name}",
+        "server_status": "http://localhost:1416/status",
+        "undeploy_pipeline": "http://localhost:1416/undeploy/{pipeline_name}",
     }

--- a/src/hayhooks/server/handlers/__init__.py
+++ b/src/hayhooks/server/handlers/__init__.py
@@ -1,7 +1,0 @@
-from hayhooks.server.handlers import deploy
-from hayhooks.server.handlers import draw
-from hayhooks.server.handlers import status
-from hayhooks.server.handlers import undeploy
-
-
-__all__ = ["deploy", "draw", "status", "undeploy"]

--- a/src/hayhooks/server/handlers/deploy.py
+++ b/src/hayhooks/server/handlers/deploy.py
@@ -1,7 +1,0 @@
-from hayhooks.server import app
-from hayhooks.server.utils.deploy_utils import deploy_pipeline_def, PipelineDefinition
-
-
-@app.post("/deploy", tags=["config"])
-async def deploy(pipeline_def: PipelineDefinition):
-    return deploy_pipeline_def(app, pipeline_def)

--- a/src/hayhooks/server/routers/__init__.py
+++ b/src/hayhooks/server/routers/__init__.py
@@ -1,0 +1,6 @@
+from hayhooks.server.routers.status import router as status_router
+from hayhooks.server.routers.draw import router as draw_router
+from hayhooks.server.routers.deploy import router as deploy_router
+from hayhooks.server.routers.undeploy import router as undeploy_router
+
+__all__ = ['status_router', 'draw_router', 'deploy_router', 'undeploy_router']

--- a/src/hayhooks/server/routers/deploy.py
+++ b/src/hayhooks/server/routers/deploy.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter, Request
+from hayhooks.server.utils.deploy_utils import deploy_pipeline_def, PipelineDefinition
+
+router = APIRouter()
+
+
+@router.post("/deploy", tags=["config"])
+async def deploy(pipeline_def: PipelineDefinition, request: Request):
+    return deploy_pipeline_def(request.app, pipeline_def)

--- a/src/hayhooks/server/routers/draw.py
+++ b/src/hayhooks/server/routers/draw.py
@@ -1,14 +1,14 @@
 import tempfile
 from pathlib import Path
-
-from fastapi import HTTPException
+from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse
-from hayhooks.server import app
 from hayhooks.server.pipelines import registry
 
+router = APIRouter()
 
-@app.get("/draw/{pipeline_name}", tags=["config"])
-async def status(pipeline_name):
+
+@router.get("/draw/{pipeline_name}", tags=["config"])
+async def draw(pipeline_name):
     pipeline = registry.get(pipeline_name)
     if not pipeline:
         raise HTTPException(status_code=404)

--- a/src/hayhooks/server/routers/status.py
+++ b/src/hayhooks/server/routers/status.py
@@ -1,15 +1,16 @@
-from fastapi import HTTPException
-from hayhooks.server import app
+from fastapi import APIRouter, HTTPException
 from hayhooks.server.pipelines import registry
 
+router = APIRouter()
 
-@app.get("/status", tags=["status"])
+
+@router.get("/status", tags=["status"])
 async def status_all():
     pipelines = registry.get_names()
     return {"status": "Up!", "pipelines": pipelines}
 
 
-@app.get("/status/{pipeline_name}", tags=["status"])
+@router.get("/status/{pipeline_name}", tags=["status"])
 async def status(pipeline_name: str):
     if pipeline_name not in registry.get_names():
         raise HTTPException(status_code=404, detail=f"Pipeline '{pipeline_name}' not found")

--- a/src/hayhooks/server/routers/undeploy.py
+++ b/src/hayhooks/server/routers/undeploy.py
@@ -1,23 +1,22 @@
 from typing import cast
-
-from fastapi import HTTPException
+from fastapi import APIRouter, HTTPException
 from fastapi.routing import APIRoute
-from hayhooks.server import app
 from hayhooks.server.pipelines import registry
 
+router = APIRouter()
 
-@app.post("/undeploy/{pipeline_name}", tags=["config"])
-async def deploy(pipeline_name: str):
+
+@router.post("/undeploy/{pipeline_name}", tags=["config"])
+async def undeploy(pipeline_name: str):
     if pipeline_name not in registry.get_names():
         raise HTTPException(status_code=404)
 
     new_routes = []
-    for route in app.router.routes:
+    for route in router.routes:
         route = cast(APIRoute, route)
         if route.name != pipeline_name:
             new_routes.append(route)
 
-    app.router.routes = new_routes
-    app.openapi_schema = None
-    app.setup()
+    router.routes = new_routes
+    router.openapi_schema = None
     registry.remove(pipeline_name)


### PR DESCRIPTION
I've refactored how currently the API routes are handled. 

Using [APIRouter](https://fastapi.tiangolo.com/reference/apirouter/), we can avoid circular imports and mypy type issues that we hd before.