### PR TITLE
Better app settings management

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+end_of_line = lf
+
+[*.{yml,yaml,ini}]
+indent_size = 2
+
+[LICENSE]
+insert_final_newline = false
+
+[Makefile]
+indent_style = tab

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Host for the FastAPI app
+HOST="localhost"
+
+# Port for the FastAPI app
+PORT=1416
+
+# Root path for the FastAPI app
+ROOT_PATH=""
+
+# Path to the folder containing the pipelines
+PIPELINES_DIR="pipelines"
+
+# Additional Python path to be added to the Python path
+ADDITIONAL_PYTHON_PATH=""

--- a/README.md
+++ b/README.md
@@ -40,6 +40,23 @@ INFO:     Waiting for application startup.
 INFO:     Application startup complete.
 INFO:     Uvicorn running on http://localhost:1416 (Press CTRL+C to quit)
 ```
+
+### Configuration
+
+Currently, you can configure the server by:
+
+- set the environment variables in an `.env` file in the root of the project
+- passing the arguments to the `run` command.
+- passing the environment variables to the `hayhooks` command.
+
+The following environment variables are supported:
+
+- `HAYHOOKS_HOST`: Host for the FastAPI app
+- `HAYHOOKS_PORT`: Port for the FastAPI app
+- `HAYHOOKS_PIPELINES_DIR`: Path to the folder containing the pipelines
+- `HAYHOOKS_ROOT_PATH`: Root path for the FastAPI app
+- `HAYHOOKS_ADDITIONAL_PYTHONPATH`: Additional Python path to be added to the Python path
+
 ### Check Hayhooks status
 
 From a different shell, you can query the status of the server with:
@@ -48,6 +65,7 @@ From a different shell, you can query the status of the server with:
 $ hayhooks status
 Hayhooks server is up and running.
 ```
+
 ### Deploy a Haystack pipeline
 
 Time to deploy a Haystack pipeline. The pipeline must be in Yaml format (the output of [`pipeline.dump()`](https://docs.haystack.deepset.ai/v2.0/docs/serialization#converting-a-pipeline-to-yaml)), if you don't have one at hand, you can use
@@ -74,7 +92,7 @@ Hayhooks will use introspection to set up the OpenAPI schema accordingly to the 
 and to see how this works let's get the pipeline diagram with:
 
 ```console
-$ curl http://localhost:1416/draw/test_pipeline_01 --output test_pipeline_01.png
+curl http://localhost:1416/draw/test_pipeline_01 --output test_pipeline_01.png
 ```
 
 The downloaded image should look like this:
@@ -134,15 +152,17 @@ Pipeline successfully undeployed
 ### Set a hayhooks server
 
 To connect to a specific server you can pass a `--server` argument to the client:
+
 ```bash
-$ hayhooks --server http://myserver:1416 status
+hayhooks --server http://myserver:1416 status
 ```
 
 #### Disable SSL verification
 
 For development purposes, you can disable SSL verification with the `--disable-ssl` flag:
+
 ```bash
-$ hayhooks --disable-ssl status
+hayhooks --disable-ssl status
 ```
 
 ## Docker setup
@@ -167,13 +187,14 @@ $ docker buildx bake
 ```
 
 There are 2 special folders in the container you can override using a `mount`:
+
 1. A folder `/opt/pipelines` containing pipeline definitions that will be automatically deployed when the container starts
 2. A folder `/opt/custom_components` containing custom components that Haystack will be able to import if part of a pipeline
 
 For example, you can mount a local `./pipelines` folder containing pipelines you want to run at start-up like this:
 
 ```console
-$ docker run --rm -p 1416:1416 -v $PWD/pipelines:/opt/pipelines "deepset/hayhooks:main"
+docker run --rm -p 1416:1416 -v $PWD/pipelines:/opt/pipelines "deepset/hayhooks:main"
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
   "requests",
   "python-multipart",
   "loguru",
+  "pydantic-settings",
+  "python-dotenv",
 ]
 
 [project.urls]

--- a/src/hayhooks/cli/run/__init__.py
+++ b/src/hayhooks/cli/run/__init__.py
@@ -1,18 +1,19 @@
 import click
 import uvicorn
-import os
 import sys
+from hayhooks.settings import settings
 
 
 @click.command()
-@click.option('--host', default="localhost")
-@click.option('--port', default=1416)
-@click.option('--pipelines-dir', default=os.environ.get("HAYHOOKS_PIPELINES_DIR"))
-@click.option('--additional-python-path', default=os.environ.get("HAYHOOKS_ADDITIONAL_PYTHONPATH"))
+@click.option('--host', default=settings.host)
+@click.option('--port', default=settings.port)
+@click.option('--pipelines-dir', default=settings.pipelines_dir)
+@click.option('--additional-python-path', default=settings.additional_python_path)
 def run(host, port, pipelines_dir, additional_python_path):
-    if not pipelines_dir:
-        pipelines_dir = "pipelines.d"
-    os.environ["HAYHOOKS_PIPELINES_DIR"] = pipelines_dir
+    settings.host = host
+    settings.port = port
+    settings.pipelines_dir = pipelines_dir
+    settings.additional_python_path = additional_python_path
 
     if additional_python_path:
         sys.path.append(additional_python_path)

--- a/src/hayhooks/cli/run/__init__.py
+++ b/src/hayhooks/cli/run/__init__.py
@@ -8,11 +8,13 @@ from hayhooks.settings import settings
 @click.option('--host', default=settings.host)
 @click.option('--port', default=settings.port)
 @click.option('--pipelines-dir', default=settings.pipelines_dir)
+@click.option('--root-path', default=settings.root_path)
 @click.option('--additional-python-path', default=settings.additional_python_path)
-def run(host, port, pipelines_dir, additional_python_path):
+def run(host, port, pipelines_dir, root_path, additional_python_path):
     settings.host = host
     settings.port = port
     settings.pipelines_dir = pipelines_dir
+    settings.root_path = root_path
     settings.additional_python_path = additional_python_path
 
     if additional_python_path:

--- a/src/hayhooks/server/app.py
+++ b/src/hayhooks/server/app.py
@@ -1,16 +1,17 @@
-from fastapi import FastAPI
+import logging
 import os
 import glob
+from fastapi import FastAPI
 from pathlib import Path
 from hayhooks.server.utils.deploy_utils import deploy_pipeline_def, PipelineDefinition
 from hayhooks.server.routers import status_router, draw_router, deploy_router, undeploy_router
-import logging
+from hayhooks.settings import settings
 
 logger = logging.getLogger("uvicorn.info")
 
 
 def create_app() -> FastAPI:
-    if root_path := os.environ.get("HAYHOOKS_ROOT_PATH"):
+    if root_path := settings.root_path:
         app = FastAPI(root_path=root_path)
     else:
         app = FastAPI()
@@ -22,7 +23,8 @@ def create_app() -> FastAPI:
     app.include_router(undeploy_router)
 
     # Deploy all pipelines in the pipelines directory
-    pipelines_dir = os.environ.get("HAYHOOKS_PIPELINES_DIR")
+    pipelines_dir = settings.pipelines_dir
+
     if pipelines_dir:
         logger.info(f"Pipelines dir set to: {pipelines_dir}")
         for pipeline_file_path in glob.glob(f"{pipelines_dir}/*.y*ml"):

--- a/src/hayhooks/settings.py
+++ b/src/hayhooks/settings.py
@@ -1,0 +1,38 @@
+from pydantic import field_validator
+from pydantic_settings import BaseSettings
+from dotenv import load_dotenv
+from pathlib import Path
+
+load_dotenv()
+
+
+class AppSettings(BaseSettings):
+    # Root path for the FastAPI app
+    root_path: str = ""
+
+    # Path to the folder containing the pipelines
+    pipelines_dir: str = "pipelines"
+
+    # Additional Python path to be added to the Python path
+    additional_python_path: str = ""
+
+    # Host for the FastAPI app
+    host: str = "localhost"
+
+    # Port for the FastAPI app
+    port: int = 1416
+
+    @field_validator("pipelines_dir")
+    def validate_pipelines_dir(cls, v):
+        path = Path(v)
+
+        if not path.exists():
+            path.mkdir(parents=True, exist_ok=True)
+
+        if not path.is_dir():
+            raise ValueError(f"pipelines_dir '{v}' exists but is not a directory")
+
+        return str(path)
+
+
+settings = AppSettings()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,64 @@
+import pytest
+import shutil
+from pathlib import Path
+from hayhooks.settings import AppSettings
+
+
+@pytest.fixture
+def temp_dir(tmp_path):
+    yield tmp_path
+
+    if tmp_path.exists():
+        shutil.rmtree(tmp_path)
+
+
+def test_default_pipelines_dir():
+    settings = AppSettings()
+
+    assert Path(settings.pipelines_dir).exists()
+    assert Path(settings.pipelines_dir).is_dir()
+
+    shutil.rmtree(settings.pipelines_dir)
+
+
+def test_custom_pipelines_dir(temp_dir):
+    custom_dir = temp_dir / "custom_pipelines"
+
+    settings = AppSettings(pipelines_dir=str(custom_dir))
+
+    assert Path(settings.pipelines_dir).exists()
+    assert Path(settings.pipelines_dir).is_dir()
+
+
+def test_invalid_pipelines_dir(temp_dir):
+    invalid_path = temp_dir / "not_a_dir"
+    invalid_path.touch()
+
+    with pytest.raises(ValueError) as exc_info:
+        AppSettings(pipelines_dir=str(invalid_path))
+
+    assert "exists but is not a directory" in str(exc_info.value)
+
+
+def test_if_pipelines_dir_does_not_exist_creates_it(temp_dir):
+    non_existing_path = temp_dir / "non_existing_dir"
+
+    settings = AppSettings(pipelines_dir=str(non_existing_path))
+
+    assert Path(settings.pipelines_dir).exists()
+    assert Path(settings.pipelines_dir).is_dir()
+
+
+def test_root_path():
+    settings = AppSettings(root_path="test_root")
+    assert settings.root_path == "test_root"
+
+
+def test_host():
+    settings = AppSettings(host="test_host")
+    assert settings.host == "test_host"
+
+
+def test_port():
+    settings = AppSettings(port=1234)
+    assert settings.port == 1234


### PR DESCRIPTION
With this, I am adding a better app settings management using [pydantic-settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/) and dotenv files.

Now all app settings are centralised in `settings.py` and they can be provided both as env variables, `hayhooks run` command args or they can simply be in a `.env` file (in the same folder where you run hayhooks).

I've also refactored all `os.environ` usages around the app.

Extra: I've added an `.editorconfig` file for better consistency across editors.