### PR TITLE
Fix /run dynamic route params

### DIFF
--- a/src/hayhooks/server/routers/openai.py
+++ b/src/hayhooks/server/routers/openai.py
@@ -90,7 +90,7 @@ async def get_models():
 @router.post("/chat/completions", response_model=ChatCompletion)
 @router.post("/{pipeline_name}/chat", response_model=ChatCompletion)
 @handle_pipeline_exceptions()
-async def chat_endpoint(chat_req: ChatRequest) -> ChatCompletion:
+async def chat_endpoint(chat_req: ChatRequest) -> Union[ChatCompletion, StreamingResponse]:
     pipeline_wrapper = registry.get(chat_req.model)
 
     if not pipeline_wrapper:

--- a/src/hayhooks/server/utils/base_pipeline_wrapper.py
+++ b/src/hayhooks/server/utils/base_pipeline_wrapper.py
@@ -5,6 +5,8 @@ from typing import Generator, List, Union
 class BasePipelineWrapper(ABC):
     def __init__(self):
         self.pipeline = None
+        self._is_run_api_implemented = False
+        self._is_run_chat_completion_implemented = False
 
     @abstractmethod
     def setup(self) -> None:

--- a/tests/test_files/files/chat_with_website/pipeline_wrapper.py
+++ b/tests/test_files/files/chat_with_website/pipeline_wrapper.py
@@ -6,9 +6,6 @@ from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
 from hayhooks.server.logger import log
 
 
-URLS = ["https://haystack.deepset.ai", "https://www.redis.io", "https://ssi.inc"]
-
-
 class PipelineWrapper(BasePipelineWrapper):
     def setup(self) -> None:
         pipeline_yaml = (Path(__file__).parent / "chat_with_website.yml").read_text()
@@ -16,8 +13,9 @@ class PipelineWrapper(BasePipelineWrapper):
 
     def run_api(self, urls: List[str], question: str) -> str:
         log.trace(f"Running pipeline with urls: {urls} and question: {question}")
-        result = self.pipeline.run({"fetcher": {"urls": urls}, "prompt": {"query": question}})
-        return result["llm"]["replies"][0]
+
+        # NOTE: This is used in tests, please don't change it
+        return "This is a mock response from the pipeline"
 
     def run_chat_completion(self, model: str, messages: List[dict], body: dict) -> Union[str, Generator]:
         log.trace(f"Running pipeline with model: {model}, messages: {messages}, body: {body}")

--- a/tests/test_files/files/run_api_error/pipeline_wrapper.py
+++ b/tests/test_files/files/run_api_error/pipeline_wrapper.py
@@ -1,9 +1,10 @@
 from haystack import Pipeline
 from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
 
+
 class PipelineWrapper(BasePipelineWrapper):
-    def setup(self):
+    def setup(self) -> None:
         self.pipeline = Pipeline()
 
     def run_api(self, test_param: str) -> str:
-        return f"Dummy result with {test_param}"
+        raise ValueError("This is a test error")


### PR DESCRIPTION
I've spotted a bad bug on which we were passing the wrong params to the `run_in_threadpool` method created on dynamic route `{pipeline_name}/run` (see changes in `deploy_utils.py`).

I've fixed it and also:

- fix some type issues (in `openai` route hander and BasePipelineWrapper class)
- made test `test_pipeline_endpoint_error_handling` more robust
