### PR TITLE
Remove app creation at module level + refactoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ PORT=1416
 # Root path for the FastAPI app
 ROOT_PATH=""
 
-# Path to the folder containing the pipelines
+# Path to the directory containing the pipelines
 PIPELINES_DIR="pipelines"
 
 # Additional Python path to be added to the Python path

--- a/.gitignore
+++ b/.gitignore
@@ -161,5 +161,5 @@ cython_debug/
 #.idea/
 
 
-# Pipelines default folder
+# Pipelines default directory
 /pipelines

--- a/src/hayhooks/cli/deploy_files/__init__.py
+++ b/src/hayhooks/cli/deploy_files/__init__.py
@@ -2,23 +2,23 @@ import click
 import requests
 from pathlib import Path
 from urllib.parse import urljoin
-from hayhooks.server.utils.deploy_utils import read_pipeline_files_from_folder
+from hayhooks.server.utils.deploy_utils import read_pipeline_files_from_dir
 
 
 @click.command()
 @click.pass_obj
 @click.option('-n', '--name', required=True, help="Name of the pipeline to deploy")
-@click.argument('folder', type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path))
-def deploy_files(server_conf, name, folder):
-    """Deploy all pipeline files from a folder to the Hayhooks server."""
+@click.argument('pipeline_dir', type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path))
+def deploy_files(server_conf, name, pipeline_dir):
+    """Deploy pipeline files from a directory to the Hayhooks server."""
     server, disable_ssl = server_conf
 
     files_dict = {}
     try:
-        files_dict = read_pipeline_files_from_folder(folder)
+        files_dict = read_pipeline_files_from_dir(pipeline_dir)
 
         if not files_dict:
-            click.echo("Error: No valid files found in the specified folder")
+            click.echo("Error: No valid files found in the specified directory")
             return
 
         resp = requests.post(
@@ -31,4 +31,4 @@ def deploy_files(server_conf, name, folder):
             click.echo(f"Pipeline successfully deployed with name: {resp.json().get('name')}")
 
     except Exception as e:
-        click.echo(f"Error processing folder: {str(e)}")
+        click.echo(f"Error processing directory: {str(e)}")

--- a/src/hayhooks/cli/run/__init__.py
+++ b/src/hayhooks/cli/run/__init__.py
@@ -1,6 +1,7 @@
 import click
 import uvicorn
 import sys
+from hayhooks.server.app import create_app
 from hayhooks.settings import settings
 
 
@@ -20,4 +21,5 @@ def run(host, port, pipelines_dir, root_path, additional_python_path):
     if additional_python_path:
         sys.path.append(additional_python_path)
 
-    uvicorn.run("hayhooks.server:app", host=host, port=port)
+    app = create_app()
+    uvicorn.run(app, host=host, port=port)

--- a/src/hayhooks/server/__init__.py
+++ b/src/hayhooks/server/__init__.py
@@ -1,4 +1,0 @@
-from hayhooks.server.app import app
-from hayhooks.server.routers import *
-
-__all__ = ["app"]

--- a/src/hayhooks/server/app.py
+++ b/src/hayhooks/server/app.py
@@ -1,10 +1,12 @@
+from os import PathLike
+from typing import Union
 from fastapi import FastAPI
 from pathlib import Path
 from hayhooks.server.utils.deploy_utils import (
     deploy_pipeline_def,
     PipelineDefinition,
     deploy_pipeline_files,
-    read_pipeline_files_from_folder,
+    read_pipeline_files_from_dir,
 )
 from hayhooks.server.routers import status_router, draw_router, deploy_router, undeploy_router, openai_router
 from hayhooks.settings import settings
@@ -44,13 +46,38 @@ def deploy_files_pipeline(app: FastAPI, pipeline_dir: Path) -> dict:
         dict: Deployment result containing pipeline name
     """
     name = pipeline_dir.name
-    files = read_pipeline_files_from_folder(pipeline_dir)
+    files = read_pipeline_files_from_dir(pipeline_dir)
 
     if files:
         deployed_pipeline = deploy_pipeline_files(app, name, files)
-        log.info(f"Deployed pipeline from directory: {deployed_pipeline['name']}")
+        log.info(f"Deployed pipeline from dir: {deployed_pipeline['name']}")
         return deployed_pipeline
     return {"name": name}
+
+
+def create_pipeline_dir(pipelines_dir: Union[PathLike, str]):
+    """
+    Create a directory for pipelines if it doesn't exist.
+
+    If the directory doesn't exist, it will be created.
+    If the directory exists but is not a directory, an error will be raised.
+
+    Args:
+        pipelines_dir: Path to the pipelines directory
+
+    Returns:
+        str: Path to the pipelines directory
+    """
+    pipelines_dir = Path(pipelines_dir)
+
+    if not pipelines_dir.exists():
+        log.info(f"Creating pipelines dir: {pipelines_dir}")
+        pipelines_dir.mkdir(parents=True, exist_ok=True)
+
+    if not pipelines_dir.is_dir():
+        raise ValueError(f"pipelines_dir '{pipelines_dir}' exists but is not a directory")
+
+    return str(pipelines_dir)
 
 
 def create_app() -> FastAPI:
@@ -62,7 +89,7 @@ def create_app() -> FastAPI:
     - Includes all router endpoints (status, draw, deploy, undeploy)
     - Auto-deploys pipelines from the configured pipelines directory:
         - YAML pipeline definitions (*.yml, *.yaml)
-        - Pipeline folders containing multiple files
+        - Pipeline directories containing multiple files
 
     Returns:
         FastAPI: Configured FastAPI application instance
@@ -80,7 +107,7 @@ def create_app() -> FastAPI:
     app.include_router(openai_router)
 
     # Deploy all pipelines in the pipelines directory
-    pipelines_dir = settings.pipelines_dir
+    pipelines_dir = create_pipeline_dir(settings.pipelines_dir)
 
     if pipelines_dir:
         log.info(f"Pipelines dir set to: {pipelines_dir}")
@@ -99,26 +126,12 @@ def create_app() -> FastAPI:
                     continue
 
         if pipeline_dirs:
-            log.info(f"Deploying {len(pipeline_dirs)} pipeline(s) from folders")
+            log.info(f"Deploying {len(pipeline_dirs)} pipeline(s) from directories")
             for pipeline_dir in pipeline_dirs:
                 try:
                     deploy_files_pipeline(app, pipeline_dir)
                 except Exception as e:
-                    log.warning(f"Skipping pipeline folder {pipeline_dir}: {str(e)}")
+                    log.warning(f"Skipping pipeline directory {pipeline_dir}: {str(e)}")
                     continue
 
     return app
-
-
-app = create_app()
-
-
-@app.get("/")
-async def root():
-    return {
-        "swagger_docs": "http://localhost:1416/docs",
-        "deploy_pipeline": "http://localhost:1416/deploy",
-        "draw_pipeline": "http://localhost:1416/draw/{pipeline_name}",
-        "server_status": "http://localhost:1416/status",
-        "undeploy_pipeline": "http://localhost:1416/undeploy/{pipeline_name}",
-    }

--- a/src/hayhooks/settings.py
+++ b/src/hayhooks/settings.py
@@ -10,8 +10,9 @@ class AppSettings(BaseSettings):
     # Root path for the FastAPI app
     root_path: str = ""
 
-    # Path to the folder containing the pipelines
-    pipelines_dir: str = "pipelines"
+    # Path to the directory containing the pipelines
+    # Default to project root / pipelines
+    pipelines_dir: str = str(Path(__file__).parent.parent.parent / "pipelines")
 
     # Additional Python path to be added to the Python path
     additional_python_path: str = ""
@@ -22,20 +23,8 @@ class AppSettings(BaseSettings):
     # Port for the FastAPI app
     port: int = 1416
 
-    # Files to ignore when reading pipeline files from a folder
+    # Files to ignore when reading pipeline files from a directory
     files_to_ignore_patterns: list[str] = ["*.pyc", "*.pyo", "*.pyd", "__pycache__", "*.so", "*.egg", "*.egg-info"]
-
-    @field_validator("pipelines_dir")
-    def validate_pipelines_dir(cls, v):
-        path = Path(v)
-
-        if not path.exists():
-            path.mkdir(parents=True, exist_ok=True)
-
-        if not path.is_dir():
-            raise ValueError(f"pipelines_dir '{v}' exists but is not a directory")
-
-        return str(path)
 
 
 settings = AppSettings()

--- a/tests/test_deploy_at_startup.py
+++ b/tests/test_deploy_at_startup.py
@@ -2,7 +2,6 @@ import pytest
 from pathlib import Path
 from fastapi.testclient import TestClient
 from hayhooks.server.app import create_app
-from hayhooks.settings import settings
 from hayhooks.server.pipelines.registry import registry
 
 
@@ -28,22 +27,22 @@ def test_mixed_pipelines_dir():
 
 
 @pytest.fixture
-def app_with_files_pipelines(test_files_pipelines_dir, monkeypatch):
-    monkeypatch.setattr(settings, "pipelines_dir", str(test_files_pipelines_dir))
+def app_with_files_pipelines(test_settings, test_files_pipelines_dir, monkeypatch):
+    monkeypatch.setattr(test_settings, "pipelines_dir", str(test_files_pipelines_dir))
     app = create_app()
     return app
 
 
 @pytest.fixture
-def app_with_yaml_pipelines(test_yaml_pipelines_dir, monkeypatch):
-    monkeypatch.setattr(settings, "pipelines_dir", str(test_yaml_pipelines_dir))
+def app_with_yaml_pipelines(test_settings, test_yaml_pipelines_dir, monkeypatch):
+    monkeypatch.setattr(test_settings, "pipelines_dir", str(test_yaml_pipelines_dir))
     app = create_app()
     return app
 
 
 @pytest.fixture
-def app_with_mixed_pipelines(test_mixed_pipelines_dir, monkeypatch):
-    monkeypatch.setattr(settings, "pipelines_dir", str(test_mixed_pipelines_dir))
+def app_with_mixed_pipelines(test_settings, test_mixed_pipelines_dir, monkeypatch):
+    monkeypatch.setattr(test_settings, "pipelines_dir", str(test_mixed_pipelines_dir))
     app = create_app()
     return app
 

--- a/tests/test_it_deploy.py
+++ b/tests/test_it_deploy.py
@@ -1,10 +1,6 @@
 import pytest
-from fastapi.testclient import TestClient
-from hayhooks.server import app
 from pathlib import Path
 from hayhooks.server.pipelines.registry import registry
-
-client = TestClient(app)
 
 
 @pytest.fixture(autouse=True)
@@ -19,7 +15,7 @@ pipeline_data = [{"name": file.stem, "source_code": file.read_text()} for file i
 
 
 @pytest.mark.parametrize("pipeline_data", pipeline_data)
-def test_deploy_pipeline_def(deploy_pipeline, status_pipeline, pipeline_data: dict):
+def test_deploy_pipeline_def(client, deploy_pipeline, status_pipeline, pipeline_data: dict):
     deploy_response = deploy_pipeline(client, pipeline_data["name"], pipeline_data["source_code"])
     assert deploy_response.status_code == 200
 
@@ -30,7 +26,7 @@ def test_deploy_pipeline_def(deploy_pipeline, status_pipeline, pipeline_data: di
     assert docs_response.status_code == 200
 
 
-def test_undeploy_pipeline_def(deploy_pipeline, undeploy_pipeline, status_pipeline):
+def test_undeploy_pipeline_def(client, deploy_pipeline, undeploy_pipeline, status_pipeline):
     pipeline_file = Path(__file__).parent / "test_files/yaml" / "working_pipelines/test_pipeline_01.yml"
     pipeline_data = {"name": pipeline_file.stem, "source_code": pipeline_file.read_text()}
 
@@ -44,11 +40,11 @@ def test_undeploy_pipeline_def(deploy_pipeline, undeploy_pipeline, status_pipeli
     assert status_response.status_code == 404
 
 
-def test_undeploy_non_existent_pipeline(undeploy_pipeline):
+def test_undeploy_non_existent_pipeline(client, undeploy_pipeline):
     undeploy_response = undeploy_pipeline(client, "non_existent_pipeline")
     assert undeploy_response.status_code == 404
 
 
-def test_undeploy_no_pipelines(undeploy_pipeline):
-    undeploy_response = undeploy_pipeline(client, "")
+def test_undeploy_no_pipelines(client, undeploy_pipeline):
+    undeploy_response = undeploy_pipeline(client, "non_existent_pipeline")
     assert undeploy_response.status_code == 404

--- a/tests/test_it_draw.py
+++ b/tests/test_it_draw.py
@@ -1,15 +1,11 @@
-from fastapi.testclient import TestClient
-from hayhooks.server import app
 from pathlib import Path
 from typing import List
 from haystack import Pipeline
 from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
 from hayhooks.server.pipelines import registry
 
-client = TestClient(app)
 
-
-def test_draw_pipeline(deploy_pipeline, draw_pipeline):
+def test_draw_pipeline(client, deploy_pipeline, draw_pipeline):
     pipeline_file = Path(__file__).parent / "test_files/yaml" / "working_pipelines/test_pipeline_01.yml"
     pipeline_data = {"name": pipeline_file.stem, "source_code": pipeline_file.read_text()}
 
@@ -22,12 +18,12 @@ def test_draw_pipeline(deploy_pipeline, draw_pipeline):
     assert len(draw_response.content) > 0
 
 
-def test_draw_non_existent_pipeline(draw_pipeline):
+def test_draw_non_existent_pipeline(client, draw_pipeline):
     draw_response = draw_pipeline(client, "non_existent_pipeline")
     assert draw_response.status_code == 404
 
 
-def test_draw_pipeline_wrapper(deploy_pipeline, draw_pipeline):
+def test_draw_pipeline_wrapper(client, deploy_pipeline, draw_pipeline):
     class TestPipelineWrapper(BasePipelineWrapper):
         def setup(self) -> None:
             pipeline_file = Path(__file__).parent / "test_files/yaml" / "working_pipelines/test_pipeline_01.yml"

--- a/tests/test_it_handling_deploy_exceptions.py
+++ b/tests/test_it_handling_deploy_exceptions.py
@@ -1,11 +1,7 @@
-from fastapi.testclient import TestClient
-from hayhooks.server import app
 from pathlib import Path
 
-client = TestClient(app)
 
-
-def test_gracefully_handle_deploy_exception(deploy_pipeline):
+def test_gracefully_handle_deploy_exception(client, deploy_pipeline):
     pipeline_name = "broken_rag_pipeline"
     pipeline_def = (Path(__file__).parent / "test_files/yaml" / "broken_rag_pipeline.yml").read_text()
 

--- a/tests/test_it_status.py
+++ b/tests/test_it_status.py
@@ -1,23 +1,20 @@
 import pytest
-from fastapi.testclient import TestClient
-from hayhooks.server import app
 from hayhooks.server.pipelines import registry
 from pathlib import Path
 
-client = TestClient(app)
 
 @pytest.fixture(autouse=True)
 def clear_registry():
     registry.clear()
 
 
-def test_status_all_pipelines(status_pipeline):
+def test_status_all_pipelines(client, status_pipeline):
     status_response = status_pipeline(client, "")
     assert status_response.status_code == 200
     assert "pipelines" in status_response.json()
 
 
-def test_status_single_pipeline(deploy_pipeline, status_pipeline):
+def test_status_single_pipeline(client, deploy_pipeline, status_pipeline):
     pipeline_file = Path(__file__).parent / "test_files/yaml" / "working_pipelines/test_pipeline_01.yml"
     pipeline_data = {"name": pipeline_file.stem, "source_code": pipeline_file.read_text()}
 
@@ -29,13 +26,13 @@ def test_status_single_pipeline(deploy_pipeline, status_pipeline):
     assert status_response.json()["pipeline"] == pipeline_data["name"]
 
 
-def test_status_non_existent_pipeline(status_pipeline):
+def test_status_non_existent_pipeline(client, status_pipeline):
     status_response = status_pipeline(client, "non_existent_pipeline")
     assert status_response.status_code == 404
     assert status_response.json()["detail"] == f"Pipeline 'non_existent_pipeline' not found"
 
 
-def test_status_no_pipelines(status_pipeline):
+def test_status_no_pipelines(client, status_pipeline):
     status_response = status_pipeline(client, "")
     assert status_response.status_code == 200
     assert "pipelines" in status_response.json()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -14,39 +14,13 @@ def temp_dir(tmp_path):
 
 def test_default_pipelines_dir():
     settings = AppSettings()
-
-    assert Path(settings.pipelines_dir).exists()
-    assert Path(settings.pipelines_dir).is_dir()
-
-    shutil.rmtree(settings.pipelines_dir)
+    assert settings.pipelines_dir == str(Path(__file__).parent.parent / "pipelines")
 
 
 def test_custom_pipelines_dir(temp_dir):
     custom_dir = temp_dir / "custom_pipelines"
-
     settings = AppSettings(pipelines_dir=str(custom_dir))
-
-    assert Path(settings.pipelines_dir).exists()
-    assert Path(settings.pipelines_dir).is_dir()
-
-
-def test_invalid_pipelines_dir(temp_dir):
-    invalid_path = temp_dir / "not_a_dir"
-    invalid_path.touch()
-
-    with pytest.raises(ValueError) as exc_info:
-        AppSettings(pipelines_dir=str(invalid_path))
-
-    assert "exists but is not a directory" in str(exc_info.value)
-
-
-def test_if_pipelines_dir_does_not_exist_creates_it(temp_dir):
-    non_existing_path = temp_dir / "non_existing_dir"
-
-    settings = AppSettings(pipelines_dir=str(non_existing_path))
-
-    assert Path(settings.pipelines_dir).exists()
-    assert Path(settings.pipelines_dir).is_dir()
+    assert settings.pipelines_dir == str(custom_dir)
 
 
 def test_root_path():


### PR DESCRIPTION
This may seems a bit convoluted, but actually contains minor refactoring and improvements:

### `app` instance

I've removed the `app` creation at module level in `app.py`. We were instantiating `app` each time that module is imported and this is not optimal. Now we're using only the `create_app` helper.

This will allow users to programmatically create their `app` instance, adding required middlewares when needed (e.g. for CORS, authentication or authorization). It's also used in `hayhooks run` CLI command. This will be better documented on another PR.

### Test improvements

- Removed the various `TestClient` instances around test files and used a single one as a fixture in `conftest.py`. 
- Override `settings` for tests, creating `pipelines` dir in `tests` dir. 
- Automatic cleanup of `pipelines` dir after each test module run.

### Folder -> Dir

There were many references to `folder` and `dir` concepts. I've chosen `dir` and removed `folder` references (but not yet in `README.md` and `deployment_guidelines.md`, another PR will take care of this).