### PR TITLE
Support for `HAYHOOKS` env var prefix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,14 @@
 # Host for the FastAPI app
-HOST="localhost"
+HAYHOOKS_HOST="localhost"
 
 # Port for the FastAPI app
-PORT=1416
+HAYHOOKS_PORT=1416
 
 # Root path for the FastAPI app
-ROOT_PATH=""
+HAYHOOKS_ROOT_PATH=""
 
 # Path to the directory containing the pipelines
-PIPELINES_DIR="pipelines"
+HAYHOOKS_PIPELINES_DIR="pipelines"
 
 # Additional Python path to be added to the Python path
-ADDITIONAL_PYTHON_PATH=""
+HAYHOOKS_ADDITIONAL_PYTHON_PATH=""

--- a/src/hayhooks/settings.py
+++ b/src/hayhooks/settings.py
@@ -1,5 +1,4 @@
-from pydantic import field_validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from dotenv import load_dotenv
 from pathlib import Path
 
@@ -28,6 +27,10 @@ class AppSettings(BaseSettings):
 
     # Files to ignore when reading pipeline files from a directory
     files_to_ignore_patterns: list[str] = ["*.pyc", "*.pyo", "*.pyd", "__pycache__", "*.so", "*.egg", "*.egg-info"]
+
+    # Prefix for the environment variables to avoid conflicts
+    # with other similar environment variables
+    model_config = SettingsConfigDict(env_prefix='hayhooks_')
 
 
 settings = AppSettings()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -12,11 +12,6 @@ def temp_dir(tmp_path):
         shutil.rmtree(tmp_path)
 
 
-def test_default_pipelines_dir():
-    settings = AppSettings()
-    assert settings.pipelines_dir == str(Path(__file__).parent.parent / "pipelines")
-
-
 def test_custom_pipelines_dir(temp_dir):
     custom_dir = temp_dir / "custom_pipelines"
     settings = AppSettings(pipelines_dir=str(custom_dir))
@@ -36,3 +31,9 @@ def test_host():
 def test_port():
     settings = AppSettings(port=1234)
     assert settings.port == 1234
+
+
+def test_env_var_prefix(monkeypatch):
+    monkeypatch.setenv("HAYHOOKS_PORT", "5678")
+    settings = AppSettings()
+    assert settings.port == 5678


### PR DESCRIPTION
As stated in README, env vars for settings should have `HAYHOOKS_*` format.

This actually add support for prefix (which was missing). Added also a test.