### PR TITLE
Add support for short and long option names

### DIFF
--- a/src/hayhooks/cli/base.py
+++ b/src/hayhooks/cli/base.py
@@ -2,7 +2,7 @@ import typer
 import sys
 import uvicorn
 import rich
-from typing import Optional
+from typing import Annotated, Optional
 from hayhooks.cli.pipeline import pipeline
 from hayhooks.cli.utils import get_server_url, make_request
 from hayhooks.server.app import create_app
@@ -27,15 +27,13 @@ def get_app():
 
 @hayhooks_cli.command()
 def run(
-    host: str = typer.Option(default=settings.host, help="Host to run the server on"),
-    port: int = typer.Option(default=settings.port, help="Port to run the server on"),
-    pipelines_dir: str = typer.Option(default=settings.pipelines_dir, help="Directory containing the pipelines"),
-    root_path: str = typer.Option(default=settings.root_path, help="Root path of the server"),
-    additional_python_path: Optional[str] = typer.Option(
-        default=settings.additional_python_path, help="Additional Python path to add to sys.path"
-    ),
-    workers: int = typer.Option(default=1, help="Number of workers to run the server with"),
-    reload: bool = typer.Option(default=False, help="Whether to reload the server on file changes"),
+    host: Annotated[str, typer.Option("--host", "-h", help="Host to run the server on")] = settings.host,
+    port: Annotated[int, typer.Option("--port", "-p", help="Port to run the server on")] = settings.port,
+    pipelines_dir: Annotated[str, typer.Option("--pipelines-dir", "-d", help="Directory containing the pipelines")] = settings.pipelines_dir,
+    root_path: Annotated[str, typer.Option(help="Root path of the server")] = settings.root_path,
+    additional_python_path: Annotated[Optional[str], typer.Option(help="Additional Python path to add to sys.path")] = settings.additional_python_path,
+    workers: Annotated[int, typer.Option("--workers", "-w", help="Number of workers to run the server with")] = 1,
+    reload: Annotated[bool, typer.Option("--reload", "-r", help="Whether to reload the server on file changes")] = False,
 ):
     """
     Run the Hayhooks server.

--- a/src/hayhooks/cli/pipeline.py
+++ b/src/hayhooks/cli/pipeline.py
@@ -51,8 +51,8 @@ def _deploy_with_progress(ctx: typer.Context, name: str, endpoint: str, payload:
 @pipeline.command()
 def deploy(
     ctx: typer.Context,
-    name: Annotated[Optional[str], typer.Option(help="The name of the pipeline to deploy.")],
-    pipeline_file: Path = typer.Option(help="The path to the pipeline file to deploy."),
+    name: Annotated[Optional[str], typer.Option("--name", "-n", help="The name of the pipeline to deploy.")],
+    pipeline_file: Path = typer.Argument(help="The path to the pipeline file to deploy."),
 ):
     """Deploy a pipeline to the Hayhooks server."""
     if not pipeline_file.exists():
@@ -68,7 +68,7 @@ def deploy(
 @pipeline.command()
 def deploy_files(
     ctx: typer.Context,
-    name: Annotated[Optional[str], typer.Option(help="The name of the pipeline to deploy.")],
+    name: Annotated[Optional[str], typer.Option("--name", "-n", help="The name of the pipeline to deploy.")],
     pipeline_dir: Path = typer.Argument(help="The path to the directory containing the pipeline files to deploy."),
 ):
     """Deploy all pipeline files from a directory to the Hayhooks server."""
@@ -95,7 +95,7 @@ def deploy_files(
 @pipeline.command()
 def undeploy(
     ctx: typer.Context,
-    name: Annotated[Optional[str], typer.Option(help="The name of the pipeline to deploy.")],
+    name: Annotated[Optional[str], typer.Option("--name", "-n", help="The name of the pipeline to deploy.")],
 ):
     """Undeploy a pipeline from the Hayhooks server."""
     response = make_request(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,3 +74,36 @@ def test_status_command(monkeypatch):
     assert result.exit_code == 0, result.output
     assert "Hayhooks server is up and running" in result.output
     assert "test_pipeline" in result.output
+
+
+def test_deploy_files_command_name_options(monkeypatch, tmp_path):
+    import hayhooks.cli.pipeline as pipeline
+
+    # Create a dummy pipeline directory with a file
+    pipeline_dir = tmp_path / "test_pipeline"
+    pipeline_dir.mkdir()
+    (pipeline_dir / "main.py").write_text("print('test')")
+
+    calls = []
+
+    def fake_deploy_with_progress(*args, **kwargs):
+        calls.append(kwargs)
+        return
+
+    monkeypatch.setattr(pipeline, "_deploy_with_progress", fake_deploy_with_progress)
+
+    # Test long form --name
+    result = runner.invoke(
+        hayhooks_cli,
+        ["pipeline", "deploy-files", "--name", "test-long", str(pipeline_dir)],
+    )
+    assert result.exit_code == 0
+    assert calls[0]["name"] == "test-long"
+
+    # Test short form -n
+    result = runner.invoke(
+        hayhooks_cli,
+        ["pipeline", "deploy-files", "-n", "test-short", str(pipeline_dir)],
+    )
+    assert result.exit_code == 0
+    assert calls[1]["name"] == "test-short"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,4 @@
 import pytest
-from pathlib import Path
 from typer.testing import CliRunner
 from hayhooks.cli.base import hayhooks_cli
 from hayhooks.settings import settings


### PR DESCRIPTION
This is to enable support of `-n` as well as `--name` for options, so commands like:

```bash
hayhooks pipeline deploy-files -n chat_with_website examples/chat_with_website
```

Will work as expected. I've also added a test for tracking this.