### PR TITLE
Cleaner imports when implementing a BasePipelineWrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ A minimal `PipelineWrapper` looks like this:
 from pathlib import Path
 from typing import List
 from haystack import Pipeline
-from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
+from hayhooks import BasePipelineWrapper
 
 class PipelineWrapper(BasePipelineWrapper):
     def setup(self) -> None:
@@ -176,9 +176,7 @@ Let's update the previous example to add a streaming response:
 from pathlib import Path
 from typing import Generator, List, Union
 from haystack import Pipeline
-from hayhooks.server.pipelines.utils import get_last_user_message
-from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
-from hayhooks.server.logger import log
+from hayhooks import get_last_user_message, BasePipelineWrapper, log
 
 
 URLS = ["https://haystack.deepset.ai", "https://www.redis.io", "https://ssi.inc"]
@@ -230,9 +228,7 @@ Let's update the `run_chat_completion` method of the previous example:
 from pathlib import Path
 from typing import Generator, List, Union
 from haystack import Pipeline
-from hayhooks.server.pipelines.utils import get_last_user_message, streaming_generator
-from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
-from hayhooks.server.logger import log
+from hayhooks import get_last_user_message, BasePipelineWrapper, log, streaming_generator
 
 
 URLS = ["https://haystack.deepset.ai", "https://www.redis.io", "https://ssi.inc"]

--- a/examples/chat_with_website/pipeline_wrapper.py
+++ b/examples/chat_with_website/pipeline_wrapper.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 from typing import Generator, List, Union
 from haystack import Pipeline
-from hayhooks.server.pipelines.utils import get_last_user_message
-from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
-from hayhooks.server.logger import log
+from hayhooks import get_last_user_message, BasePipelineWrapper, log
 
 
 URLS = ["https://haystack.deepset.ai", "https://www.redis.io", "https://ssi.inc"]

--- a/examples/chat_with_website_streaming/pipeline_wrapper.py
+++ b/examples/chat_with_website_streaming/pipeline_wrapper.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 from typing import Generator, List, Union
 from haystack import Pipeline
-from hayhooks.server.pipelines.utils import get_last_user_message, streaming_generator
-from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
-from hayhooks.server.logger import log
+from hayhooks import get_last_user_message, BasePipelineWrapper, log, streaming_generator
 
 
 URLS = ["https://haystack.deepset.ai", "https://www.redis.io", "https://ssi.inc"]

--- a/src/hayhooks/__init__.py
+++ b/src/hayhooks/__init__.py
@@ -1,0 +1,15 @@
+from hayhooks.server.logger import log
+from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
+from hayhooks.server.pipelines.utils import (
+    is_user_message,
+    get_last_user_message,
+    streaming_generator,
+)
+
+__all__ = [
+    "log",
+    "BasePipelineWrapper",
+    "is_user_message",
+    "get_last_user_message",
+    "streaming_generator",
+]

--- a/src/hayhooks/server/pipelines/utils.py
+++ b/src/hayhooks/server/pipelines/utils.py
@@ -16,7 +16,7 @@ def is_user_message(msg: Union[Message, Dict]) -> bool:
 def get_content(msg: Union[Message, Dict]) -> str:
     if isinstance(msg, Message):
         return msg.content
-    return msg.get("content")
+    return msg.get("content", "")
 
 
 def get_last_user_message(messages: List[Union[Message, Dict]]) -> Union[str, None]:
@@ -28,7 +28,7 @@ def get_last_user_message(messages: List[Union[Message, Dict]]) -> Union[str, No
     return None
 
 
-def find_streaming_component(pipeline) -> Tuple[Component, str]:
+def find_streaming_component(pipeline: Pipeline) -> Tuple[Component, str]:
     """
     Finds the component in the pipeline that supports streaming_callback
 
@@ -36,7 +36,7 @@ def find_streaming_component(pipeline) -> Tuple[Component, str]:
         The first component that supports streaming
     """
     streaming_component = None
-    streaming_component_name = None
+    streaming_component_name = ""
 
     for name, component in pipeline.walk():
         if hasattr(component, "streaming_callback"):
@@ -54,7 +54,7 @@ def streaming_generator(pipeline: Pipeline, pipeline_run_args: Dict) -> Generato
     Creates a generator that yields streaming chunks from a pipeline execution.
     Automatically finds the streaming-capable component in the pipeline.
     """
-    queue = Queue()
+    queue: Queue[str] = Queue()
 
     def streaming_callback(chunk):
         queue.put(chunk.content)

--- a/tests/test_files/files/chat_with_website/pipeline_wrapper.py
+++ b/tests/test_files/files/chat_with_website/pipeline_wrapper.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 from typing import Generator, List, Union
 from haystack import Pipeline
-from hayhooks.server.pipelines.utils import get_last_user_message
-from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
-from hayhooks.server.logger import log
+from hayhooks import get_last_user_message, BasePipelineWrapper, log
 
 
 class PipelineWrapper(BasePipelineWrapper):

--- a/tests/test_files/files/chat_with_website_streaming/pipeline_wrapper.py
+++ b/tests/test_files/files/chat_with_website_streaming/pipeline_wrapper.py
@@ -1,10 +1,7 @@
 from pathlib import Path
-from pprint import pprint
 from typing import Generator, List, Union
 from haystack import Pipeline
-from hayhooks.server.pipelines.utils import get_last_user_message, streaming_generator
-from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
-from hayhooks.server.logger import log
+from hayhooks import get_last_user_message, BasePipelineWrapper, log
 
 
 URLS = ["https://haystack.deepset.ai", "https://www.redis.io", "https://ssi.inc"]

--- a/tests/test_files/files/missing_methods/pipeline_wrapper.py
+++ b/tests/test_files/files/missing_methods/pipeline_wrapper.py
@@ -1,5 +1,6 @@
-from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
+from hayhooks import BasePipelineWrapper
 from haystack import Pipeline
+
 
 class PipelineWrapper(BasePipelineWrapper):
     def setup(self):

--- a/tests/test_files/files/no_chat/pipeline_wrapper.py
+++ b/tests/test_files/files/no_chat/pipeline_wrapper.py
@@ -1,5 +1,6 @@
 from haystack import Pipeline
-from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
+from hayhooks import BasePipelineWrapper
+
 
 class PipelineWrapper(BasePipelineWrapper):
     def setup(self):

--- a/tests/test_files/files/run_api_error/pipeline_wrapper.py
+++ b/tests/test_files/files/run_api_error/pipeline_wrapper.py
@@ -1,5 +1,5 @@
 from haystack import Pipeline
-from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
+from hayhooks import BasePipelineWrapper
 
 
 class PipelineWrapper(BasePipelineWrapper):

--- a/tests/test_files/files/setup_error/pipeline_wrapper.py
+++ b/tests/test_files/files/setup_error/pipeline_wrapper.py
@@ -1,4 +1,5 @@
-from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
+from hayhooks import BasePipelineWrapper
+
 
 class PipelineWrapper(BasePipelineWrapper):
     def setup(self):

--- a/tests/test_files/mixed/chat_with_website/pipeline_wrapper.py
+++ b/tests/test_files/mixed/chat_with_website/pipeline_wrapper.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 from typing import List
 from haystack import Pipeline
-from hayhooks.server.pipelines.utils import get_last_user_message
-from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
-from hayhooks.server.logger import log
+from hayhooks import get_last_user_message, BasePipelineWrapper, log
 
 
 URLS = ["https://haystack.deepset.ai", "https://www.redis.io"]


### PR DESCRIPTION
I've exposed some imports directly in `hayhooks` init to make them cleaner when it comes to implement a `BasePipelineWrapper` and so create a pipeline wrapper.

Basically, here's how they looked:

```python
from hayhooks.server.pipelines.utils import get_last_user_message, streaming_generator
from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
from hayhooks.server.logger import log
```

And this is how they look now:

```python
from hayhooks import get_last_user_message, BasePipelineWrapper, log, streaming_generator
```

I've also updated README and `/examples` folder.