### PR TITLE
Support 'overwrite' and 'skip-saving-files' options on pipeline deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,15 @@ It provides a simple way to wrap your Haystack pipelines with custom logic and e
   - [Setup Method](#setup)
   - [Run API Method](#run_api)
   - [Additional Dependencies](#additional-dependencies)
+  - [PipelineWrapper development with `overwrite` option](#pipelinewrapper-development-with-overwrite-option)
 - [OpenAI Compatibility](#openai-compatible-endpoints-generation)
   - [Chat Completion Method](#run_chat_completion)
   - [Streaming Responses](#streaming-responses-in-openai-compatible-endpoints)
   - [Integration with haystack OpenAIChatGenerator](#integration-with-haystack-openaichatgenerator)
-- [Run Hayhooks Programmatically](#run-hayhooks-programmatically)
-- [Deploy Pipeline Using YAML](#deploy-a-pipeline-using-only-its-yaml-definition)
-- [Deployment](#deployment)
+- [Advanced Usage](#advanced-usage)
+  - [Run Hayhooks Programmatically](#run-hayhooks-programmatically)
+  - [Deploy Pipeline Using YAML](#deploy-a-pipeline-using-only-its-yaml-definition)
+  - [Deployment Guidelines](#deployment)
 - [License](#license)
 
 ## Quick start
@@ -37,7 +39,7 @@ It provides a simple way to wrap your Haystack pipelines with custom logic and e
 
 Start by installing the package:
 
-```console
+```shell
 pip install hayhooks
 ```
 
@@ -81,7 +83,7 @@ hayhooks pipeline undeploy <pipeline_name>     # Undeploy a pipeline
 
 Let's start Hayhooks:
 
-```console
+```shell
 hayhooks run
 ```
 
@@ -151,6 +153,38 @@ hayhooks pipeline deploy-files -n chat_with_website examples/chat_with_website
 ```
 
 This will deploy the pipeline with the name `chat_with_website`. Any error encountered during development will be printed to the console and show in the server logs.
+
+#### PipelineWrapper development with overwrite option
+
+During development, you can use the `--overwrite` flag to redeploy your pipeline without restarting the Hayhooks server:
+
+```shell
+hayhooks pipeline deploy-files -n {pipeline_name} --overwrite {pipeline_dir}
+```
+
+This is particularly useful when:
+
+- Iterating on your pipeline wrapper implementation
+- Debugging pipeline setup issues
+- Testing different pipeline configurations
+
+The `--overwrite` flag will:
+
+1. Remove the existing pipeline from the registry
+2. Delete the pipeline files from disk
+3. Deploy the new version of your pipeline
+
+For even faster development iterations, you can combine `--overwrite` with `--skip-saving-files` to avoid writing files to disk:
+
+```shell
+hayhooks pipeline deploy-files -n {pipeline_name} --overwrite --skip-saving-files {pipeline_dir}
+```
+
+This is useful when:
+
+- You're making frequent changes during development
+- You want to test a pipeline without persisting it
+- You're running in an environment with limited disk access
 
 #### Additional dependencies
 

--- a/src/hayhooks/cli/pipeline.py
+++ b/src/hayhooks/cli/pipeline.py
@@ -70,6 +70,12 @@ def deploy_files(
     ctx: typer.Context,
     name: Annotated[Optional[str], typer.Option("--name", "-n", help="The name of the pipeline to deploy.")],
     pipeline_dir: Path = typer.Argument(help="The path to the directory containing the pipeline files to deploy."),
+    overwrite: Annotated[
+        bool, typer.Option("--overwrite", "-o", help="Whether to overwrite the pipeline if it already exists.")
+    ] = False,
+    skip_saving_files: Annotated[
+        bool, typer.Option("--skip-saving-files", "-s", help="Whether to skip saving the files to the server.")
+    ] = False,
 ):
     """Deploy all pipeline files from a directory to the Hayhooks server."""
     if not pipeline_dir.exists():
@@ -88,7 +94,7 @@ def deploy_files(
     if name is None:
         name = pipeline_dir.stem
 
-    payload = {"name": name, "files": files_dict}
+    payload = {"name": name, "files": files_dict, "save_files": not skip_saving_files, "overwrite": overwrite}
     _deploy_with_progress(ctx=ctx, name=name, endpoint="deploy_files", payload=payload)
 
 

--- a/src/hayhooks/server/routers/deploy.py
+++ b/src/hayhooks/server/routers/deploy.py
@@ -27,14 +27,14 @@ async def deploy(pipeline_def: PipelineDefinition, request: Request):
 
 
 @router.post("/deploy_files", tags=["config"])
-async def deploy_files(pipeline_files: PipelineFilesRequest, request: Request):
+async def deploy_files(pipeline_files_request: PipelineFilesRequest, request: Request):
     try:
         return deploy_pipeline_files(
             app=request.app,
-            pipeline_name=pipeline_files.name,
-            files=pipeline_files.files,
-            save_files=pipeline_files.save_files,
-            overwrite=pipeline_files.overwrite,
+            pipeline_name=pipeline_files_request.name,
+            files=pipeline_files_request.files,
+            save_files=pipeline_files_request.save_files,
+            overwrite=pipeline_files_request.overwrite,
         )
     except PipelineFilesError as e:
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/src/hayhooks/server/routers/deploy.py
+++ b/src/hayhooks/server/routers/deploy.py
@@ -17,6 +17,8 @@ router = APIRouter()
 class PipelineFilesRequest(BaseModel):
     name: str
     files: Dict[str, str]
+    overwrite: bool = False
+    save_files: bool = True
 
 
 @router.post("/deploy", tags=["config"])
@@ -27,14 +29,20 @@ async def deploy(pipeline_def: PipelineDefinition, request: Request):
 @router.post("/deploy_files", tags=["config"])
 async def deploy_files(pipeline_files: PipelineFilesRequest, request: Request):
     try:
-        return deploy_pipeline_files(request.app, pipeline_files.name, pipeline_files.files)
+        return deploy_pipeline_files(
+            app=request.app,
+            pipeline_name=pipeline_files.name,
+            files=pipeline_files.files,
+            save_files=pipeline_files.save_files,
+            overwrite=pipeline_files.overwrite,
+        )
     except PipelineFilesError as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=str(e)) from e
     except PipelineModuleLoadError as e:
-        raise HTTPException(status_code=422, detail=str(e))
+        raise HTTPException(status_code=422, detail=str(e)) from e
     except PipelineWrapperError as e:
-        raise HTTPException(status_code=422, detail=str(e))
+        raise HTTPException(status_code=422, detail=str(e)) from e
     except PipelineAlreadyExistsError as e:
-        raise HTTPException(status_code=409, detail=str(e))
+        raise HTTPException(status_code=409, detail=str(e)) from e
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Unexpected error deploying pipeline: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Unexpected error deploying pipeline: {str(e)}") from e

--- a/src/hayhooks/server/utils/deploy_utils.py
+++ b/src/hayhooks/server/utils/deploy_utils.py
@@ -236,14 +236,14 @@ def deploy_pipeline_files(
 
     log.debug(f"Checking if pipeline '{pipeline_name}' already exists: {registry.get(pipeline_name)}")
     if registry.get(pipeline_name):
-        if not overwrite:
-            raise PipelineAlreadyExistsError(f"Pipeline '{pipeline_name}' already exists")
-        else:
+        if overwrite:
             log.debug(f"Clearing existing pipeline '{pipeline_name}'")
             registry.remove(pipeline_name)
 
             log.debug(f"Removing pipeline files for '{pipeline_name}'")
             remove_pipeline_files(pipeline_name, settings.pipelines_dir)
+        else:
+            raise PipelineAlreadyExistsError(f"Pipeline '{pipeline_name}' already exists")
 
     tmp_dir = None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,9 +72,21 @@ def status_pipeline():
 
 
 @pytest.fixture
+def chat_completion():
+    def _chat_completion(client: TestClient, pipeline_name: str, messages: list):
+        chat_response = client.post(f"/{pipeline_name}/chat", json={"messages": messages, "model": pipeline_name})
+        return chat_response
+
+    return _chat_completion
+
+
+@pytest.fixture
 def deploy_files():
-    def _deploy_files(client: TestClient, pipeline_name: str, pipeline_files: dict):
-        deploy_response = client.post("/deploy_files", json={"name": pipeline_name, "files": pipeline_files})
+    def _deploy_files(client: TestClient, pipeline_name: str, pipeline_files: dict, overwrite: bool = False):
+        deploy_response = client.post(
+            "/deploy_files",
+            json={"name": pipeline_name, "files": pipeline_files, "overwrite": overwrite},
+        )
         return deploy_response
 
     return _deploy_files

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,10 +82,12 @@ def chat_completion():
 
 @pytest.fixture
 def deploy_files():
-    def _deploy_files(client: TestClient, pipeline_name: str, pipeline_files: dict, overwrite: bool = False):
+    def _deploy_files(
+        client: TestClient, pipeline_name: str, pipeline_files: dict, overwrite: bool = False, save_files: bool = True
+    ):
         deploy_response = client.post(
             "/deploy_files",
-            json={"name": pipeline_name, "files": pipeline_files, "overwrite": overwrite},
+            json={"name": pipeline_name, "files": pipeline_files, "overwrite": overwrite, "save_files": save_files},
         )
         return deploy_response
 

--- a/tests/test_deploy_utils.py
+++ b/tests/test_deploy_utils.py
@@ -194,18 +194,13 @@ def test_deploy_pipeline_files_without_saving(test_settings, mocker):
     test_file_path = Path("tests/test_files/files/no_chat/pipeline_wrapper.py")
     files = {"pipeline_wrapper.py": test_file_path.read_text()}
 
-    # Save the files to the pipelines directory
-    save_pipeline_files("test_pipeline", files, pipelines_dir=test_settings.pipelines_dir)
-
-    # Now we mock the save_pipeline_files function to ensure it's not called during the deploy
-    mock_save = mocker.patch('hayhooks.server.utils.deploy_utils.save_pipeline_files')
-
     # Run deploy_pipeline_files without saving the files
     result = deploy_pipeline_files(app=mock_app, pipeline_name="test_pipeline", files=files, save_files=False)
     assert result == {"name": "test_pipeline"}
 
-    # Verify save_pipeline_files was not called
-    mock_save.assert_not_called()
+    # Check that pipeline files are not saved to disk
+    pipeline_dir = Path(test_settings.pipelines_dir) / "test_pipeline"
+    assert not pipeline_dir.exists()
 
     # Verify the pipeline was deployed successfully
     assert result == {"name": "test_pipeline"}


### PR DESCRIPTION
![Screenshot 2025-02-21 at 10 37 34](https://github.com/user-attachments/assets/149d14de-19ce-4835-aa7d-61ffaed7da56)

This is to:

- Support `overwrite` option on `deploy-files` command and `/deploy-files` API route.
- Expose `skip-saving-files` option on `deploy-files` command and `/deploy-files` API route.

The main reason behind this is to ease the development phase of the pipeline wrapper. So now one can deploy a pipeline multiple subsequent times doing:

```shell
hayhooks pipeline deploy-files -n {pipeline_name} {pipeline_folder_path} --overwrite
```

multiple times without getting the `409 conflict - pipeline already exists` error. The pipeline files will be replaced and the pipeline will be reloaded without the need to manually removing files or call `/undeploy` API.

I've also exposed the `skip-saving-files` option, which allows deploy without saving files (so deployed pipelines will not be reloaded on Hayhooks server restarts).

I've also did some minor tests refactoring.