### PR TITLE
Move CORS validation at app instance creation time

### DIFF
--- a/src/hayhooks/server/app.py
+++ b/src/hayhooks/server/app.py
@@ -11,7 +11,7 @@ from hayhooks.server.utils.deploy_utils import (
     read_pipeline_files_from_dir,
 )
 from hayhooks.server.routers import status_router, draw_router, deploy_router, undeploy_router, openai_router
-from hayhooks.settings import settings
+from hayhooks.settings import settings, check_cors_settings
 from hayhooks.server.logger import log
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -146,6 +146,9 @@ def create_app() -> FastAPI:
         app = FastAPI(root_path=root_path, lifespan=lifespan)
     else:
         app = FastAPI(lifespan=lifespan)
+
+    # Check CORS settings before adding middleware
+    check_cors_settings()
 
     # Add CORS middleware
     app.add_middleware(

--- a/src/hayhooks/server/utils/deploy_utils.py
+++ b/src/hayhooks/server/utils/deploy_utils.py
@@ -127,8 +127,9 @@ def load_pipeline_module(pipeline_name: str, dir_path: Union[Path, str]) -> Modu
     Raises:
         ValueError: If the module cannot be loaded
     """
-    log.warning(f"Loading pipeline module from {dir_path}")
-    log.warning(f"Is folder present: {Path(dir_path).exists()}")
+    log.trace(f"Loading pipeline module from {dir_path}")
+    log.trace(f"Is folder present: {Path(dir_path).exists()}")
+
     try:
         dir_path = Path(dir_path)
         wrapper_path = dir_path / "pipeline_wrapper.py"

--- a/src/hayhooks/settings.py
+++ b/src/hayhooks/settings.py
@@ -1,7 +1,6 @@
 from typing import Union
 from warnings import warn
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from pydantic import model_validator
 from dotenv import load_dotenv, find_dotenv
 from pathlib import Path
 
@@ -47,11 +46,14 @@ class AppSettings(BaseSettings):
     # with other similar environment variables
     model_config = SettingsConfigDict(env_prefix='hayhooks_')
 
-    @model_validator(mode="after")
-    def check_if_cors_are_configured(self):
-        if self.cors_allow_origins == ["*"] and self.cors_allow_methods == ["*"] and self.cors_allow_headers == ["*"]:
-            warn("Using default CORS settings - All origins, methods, and headers are allowed.")
-        return self
-
 
 settings = AppSettings()
+
+
+def check_cors_settings():
+    if (
+        settings.cors_allow_origins == ["*"]
+        and settings.cors_allow_methods == ["*"]
+        and settings.cors_allow_headers == ["*"]
+    ):
+        warn("Using default CORS settings - All origins, methods, and headers are allowed.")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,7 +1,7 @@
 import warnings
 import pytest
 import shutil
-from hayhooks.settings import AppSettings
+from hayhooks.settings import AppSettings, check_cors_settings
 
 
 @pytest.fixture
@@ -90,7 +90,7 @@ def test_cors_warning():
     with pytest.warns(
         UserWarning, match="Using default CORS settings - All origins, methods, and headers are allowed."
     ):
-        AppSettings()
+        check_cors_settings()
 
     with warnings.catch_warnings(record=True) as recorded_warnings:
         warnings.simplefilter("always")


### PR DESCRIPTION
This is a minor refactor to move CORS validation function at app instance creation time (previously was a settings creation level). This is to avoid trigger CORS validation when it's not needed and also to make code cleaner.