### PR TITLE
Deploying an updated pipeline with `overwrite` option should also run updated code

### DIFF
--- a/tests/test_deploy_utils.py
+++ b/tests/test_deploy_utils.py
@@ -1,3 +1,4 @@
+from fastapi.routing import APIRoute
 import pytest
 import shutil
 from haystack import Pipeline
@@ -190,9 +191,12 @@ def test_create_pipeline_wrapper_instance_missing_methods():
 def test_deploy_pipeline_files_without_saving(test_settings, mocker):
     mock_app = mocker.Mock()
 
-    # We're saving the pipeline wrapper file in the test_files directory
+    # We're saving the pipeline wrapper file in the test_files directory
     test_file_path = Path("tests/test_files/files/no_chat/pipeline_wrapper.py")
     files = {"pipeline_wrapper.py": test_file_path.read_text()}
+
+    # Mock the app routes to mimic the existing route
+    mock_app.routes = [APIRoute(path="/test_pipeline/run", endpoint=lambda: None, methods=["POST"])]
 
     # Run deploy_pipeline_files without saving the files
     result = deploy_pipeline_files(app=mock_app, pipeline_name="test_pipeline", files=files, save_files=False)


### PR DESCRIPTION
I noticed a nasty bug: if you deploy consequently a pipeline using `--overwrite` option (or `overwrite` param on `/deploy-files` API) doesn't actually run the updated code. 

In the existing tests, we were adding to updated files the `run_chat_completion` method (and it was working), but we didn't try e.g. to update the code of `run_api`. Indeed it wasn't working due to python import cache and due to the fact that FastAPI doesn't replace the existing route using `app.add_api_route`.

With this, we:

- Clear the module from sys.modules if it exists to ensure a fresh load
- Clear existing pipeline run API route if it exists on FastAPI `app` instance

I've also added a test where we change the actual wrapper code between two deploys using `overwrite` option.