### PR TITLE
Make additional_python_path setting work also settings related env var

### DIFF
--- a/src/hayhooks/server/app.py
+++ b/src/hayhooks/server/app.py
@@ -1,3 +1,4 @@
+import sys
 from os import PathLike
 from typing import Union
 from fastapi import FastAPI
@@ -142,6 +143,10 @@ def create_app() -> FastAPI:
     Returns:
         FastAPI: Configured FastAPI application instance
     """
+    if additional_path := settings.additional_python_path:
+        sys.path.append(additional_path)
+        log.trace(f"Added {additional_path} to sys.path")
+
     if root_path := settings.root_path:
         app = FastAPI(root_path=root_path, lifespan=lifespan)
     else:


### PR DESCRIPTION
Fixes #82.

Explanation of previous situation is [here](https://github.com/deepset-ai/hayhooks/issues/82#issuecomment-2694529010).

With this, `additional_python_path` works correctly both via CLI and setting `HAYHOOKS_ADDITIONAL_PYTHON_PATH` env var.
