### PR TITLE
Remove pandas reference and pin haystack-ai to >=2.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai",
+  "haystack-ai>=2.11.0",
   "fastapi[standard]",
   "typer",
   "uvicorn",

--- a/src/hayhooks/server/pipelines/models.py
+++ b/src/hayhooks/server/pipelines/models.py
@@ -1,4 +1,3 @@
-from pandas import DataFrame
 from pydantic import BaseModel, ConfigDict, create_model
 from hayhooks.server.utils.create_valid_type import handle_unsupported_types
 from haystack import Document
@@ -10,7 +9,6 @@ class PipelineDefinition(BaseModel):
 
 
 DEFAULT_TYPES_MAPPING = {
-    DataFrame: dict,
     Document: dict,
 }
 


### PR DESCRIPTION
With this:

- I've removed the import of `DataFrame` from `pandas` which was used in legacy YAML-only based deployment type mapping
- Pin Haystack to >=2.11.0 to ensure that `DataFrame` is not anymore inside `Document`