### PR TITLE
Remove warnings.warn in favour of log.warning

### DIFF
--- a/src/hayhooks/settings.py
+++ b/src/hayhooks/settings.py
@@ -1,8 +1,8 @@
 from typing import Union
-from warnings import warn
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from dotenv import load_dotenv, find_dotenv
 from pathlib import Path
+from hayhooks.server.logger import log
 
 load_dotenv(dotenv_path=find_dotenv(usecwd=True))
 
@@ -62,4 +62,4 @@ def check_cors_settings():
         and settings.cors_allow_methods == ["*"]
         and settings.cors_allow_headers == ["*"]
     ):
-        warn("Using default CORS settings - All origins, methods, and headers are allowed.", UserWarning)
+        log.warning("Using default CORS settings - All origins, methods, and headers are allowed.")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,3 @@
-import importlib
 import sys
 import warnings
 import pytest

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4,6 +4,7 @@ import pytest
 import shutil
 from hayhooks.server.app import create_app
 from hayhooks.settings import AppSettings, check_cors_settings
+from unittest.mock import patch
 
 
 @pytest.fixture
@@ -89,19 +90,19 @@ def test_cors_env_vars(monkeypatch):
 
 
 def test_cors_warning():
-    with pytest.warns(
-        UserWarning, match="Using default CORS settings - All origins, methods, and headers are allowed."
-    ):
+    with patch("hayhooks.settings.log.warning") as mock_log_warning:
         check_cors_settings()
+        mock_log_warning.assert_called_once_with(
+            "Using default CORS settings - All origins, methods, and headers are allowed."
+        )
 
-    with warnings.catch_warnings(record=True) as recorded_warnings:
-        warnings.simplefilter("always")
+    with patch("hayhooks.settings.log.warning") as mock_log_warning:
         AppSettings(
             cors_allow_origins=["https://example.com"],
             cors_allow_methods=["GET", "POST"],
             cors_allow_headers=["X-Custom-Header"],
         )
-        assert len(recorded_warnings) == 0
+        mock_log_warning.assert_not_called()
 
 
 def test_additional_python_path():


### PR DESCRIPTION
This simply remove a `warnings.warn` usage in favour of `log.warning`, to align warnings usage policy to Haystack's one.