### PR TITLE
Improve app and models metadata

### DIFF
--- a/src/hayhooks/server/app.py
+++ b/src/hayhooks/server/app.py
@@ -1,5 +1,6 @@
 import sys
 import requests
+from functools import lru_cache
 from os import PathLike
 from typing import Union
 from fastapi import FastAPI
@@ -132,6 +133,7 @@ async def lifespan(app: FastAPI):
     yield
 
 
+@lru_cache(maxsize=1)
 def get_package_version_from_pypi(package_name: str) -> str:
     """
     Get the version of the package from PyPI.

--- a/src/hayhooks/server/routers/deploy.py
+++ b/src/hayhooks/server/routers/deploy.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Request, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
 from typing import Dict
 from hayhooks.server.exceptions import PipelineAlreadyExistsError
 from hayhooks.server.utils.deploy_utils import (
@@ -15,27 +15,80 @@ router = APIRouter()
 
 
 class PipelineFilesRequest(BaseModel):
-    name: str
-    files: Dict[str, str]
-    overwrite: bool = False
-    save_files: bool = True
+    name: str = Field(description="Name of the pipeline to deploy")
+    files: Dict[str, str] = Field(
+        description="Dictionary of files required for the pipeline, must include pipeline_wrapper.py",
+        examples=[
+            {
+                "pipeline_wrapper.py": "from typing import Dict, Any\n\ndef process(data: Dict[str, Any]) -> Dict[str, Any]:\n    # Your processing logic here\n    return data",
+                "requirements.txt": "pandas==1.3.5\nnumpy==1.21.0",
+            }
+        ],
+    )
+    overwrite: bool = Field(default=False, description="Whether to overwrite an existing pipeline with the same name")
+    save_files: bool = Field(default=True, description="Whether to save the pipeline files to disk")
+
+    model_config = {
+        "json_schema_extra": {
+            "description": "Request model for deploying a pipeline with a pipeline_wrapper.py and other files",
+            "examples": [
+                {
+                    "name": "my_pipeline",
+                    "files": {
+                        "pipeline_wrapper.py": "{python code}",
+                        "other_file.py": "{python code}",
+                        "other_file.txt": "{text content}",
+                    },
+                    "overwrite": False,
+                    "save_files": True,
+                }
+            ],
+        }
+    }
+
+    @field_validator('files')
+    @classmethod
+    def validate_files(cls, v: Dict[str, str]) -> Dict[str, str]:
+        if "pipeline_wrapper.py" not in v:
+            raise ValueError("Missing required file: pipeline_wrapper.py")
+        return v
 
 
-@router.post("/deploy", tags=["config"])
+class DeployResponse(BaseModel):
+    name: str = Field(description="Name of the deployed pipeline")
+
+    model_config = {"json_schema_extra": {"description": "Response model for pipeline deployment operations"}}
+
+
+@router.post(
+    "/deploy",
+    tags=["config"],
+    response_model=DeployResponse,
+    summary="Deploy a pipeline from YAML definition",
+    description="Deploys a pipeline from a PipelineDefinition object. Returns 409 if the pipeline already exists and overwrite is false.",
+)
 async def deploy(pipeline_def: PipelineDefinition, request: Request):
-    return deploy_pipeline_def(request.app, pipeline_def)
+    result = deploy_pipeline_def(request.app, pipeline_def)
+    return DeployResponse(name=result["name"])
 
 
-@router.post("/deploy_files", tags=["config"])
+@router.post(
+    "/deploy_files",
+    tags=["config"],
+    response_model=DeployResponse,
+    summary="Deploy a pipeline from files (`pipeline_wrapper.py` and other files)",
+    description="Deploys a pipeline from a dictionary of file contents. Returns 409 if the pipeline already exists and overwrite is false.",
+)
 async def deploy_files(pipeline_files_request: PipelineFilesRequest, request: Request):
     try:
-        return deploy_pipeline_files(
+        result = deploy_pipeline_files(
             app=request.app,
             pipeline_name=pipeline_files_request.name,
             files=pipeline_files_request.files,
             save_files=pipeline_files_request.save_files,
             overwrite=pipeline_files_request.overwrite,
         )
+        return DeployResponse(name=result["name"])
     except PipelineFilesError as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
     except PipelineModuleLoadError as e:

--- a/src/hayhooks/server/routers/deploy.py
+++ b/src/hayhooks/server/routers/deploy.py
@@ -14,16 +14,19 @@ from hayhooks.server.utils.deploy_utils import (
 router = APIRouter()
 
 
+SAMPLE_PIPELINE_FILES = {
+    "pipeline_wrapper.py": (
+        "from typing import Dict, Any\n\ndef process(data: Dict[str, Any]) -> Dict[str, Any]:\n    # Your processing logic here\n    return data"
+    ),
+    "requirements.txt": "pandas==1.3.5\nnumpy==1.21.0",
+}
+
+
 class PipelineFilesRequest(BaseModel):
     name: str = Field(description="Name of the pipeline to deploy")
     files: Dict[str, str] = Field(
         description="Dictionary of files required for the pipeline, must include pipeline_wrapper.py",
-        examples=[
-            {
-                "pipeline_wrapper.py": "from typing import Dict, Any\n\ndef process(data: Dict[str, Any]) -> Dict[str, Any]:\n    # Your processing logic here\n    return data",
-                "requirements.txt": "pandas==1.3.5\nnumpy==1.21.0",
-            }
-        ],
+        examples=[SAMPLE_PIPELINE_FILES],
     )
     overwrite: bool = Field(default=False, description="Whether to overwrite an existing pipeline with the same name")
     save_files: bool = Field(default=True, description="Whether to save the pipeline files to disk")
@@ -64,8 +67,14 @@ class DeployResponse(BaseModel):
     "/deploy",
     tags=["config"],
     response_model=DeployResponse,
-    summary="Deploy a pipeline from YAML definition",
-    description="Deploys a pipeline from a PipelineDefinition object. Returns 409 if the pipeline already exists and overwrite is false.",
+    summary="Deploy a pipeline from YAML definition (Not Maintained)",
+    description=(
+        "[DEPRECATED] This route is no longer maintained and will be removed in a future version. "
+        "Please use /deploy_files endpoint instead. "
+        "Deploys a pipeline from a PipelineDefinition object. "
+        "Returns 409 if the pipeline already exists and overwrite is false."
+    ),
+    deprecated=True,
 )
 async def deploy(pipeline_def: PipelineDefinition, request: Request):
     result = deploy_pipeline_def(request.app, pipeline_def)
@@ -77,7 +86,10 @@ async def deploy(pipeline_def: PipelineDefinition, request: Request):
     tags=["config"],
     response_model=DeployResponse,
     summary="Deploy a pipeline from files (`pipeline_wrapper.py` and other files)",
-    description="Deploys a pipeline from a dictionary of file contents. Returns 409 if the pipeline already exists and overwrite is false.",
+    description=(
+        "Deploys a pipeline from a dictionary of file contents. "
+        "Returns 409 if the pipeline already exists and overwrite is false."
+    ),
 )
 async def deploy_files(pipeline_files_request: PipelineFilesRequest, request: Request):
     try:

--- a/src/hayhooks/server/routers/deploy.py
+++ b/src/hayhooks/server/routers/deploy.py
@@ -69,6 +69,7 @@ class DeployResponse(BaseModel):
     "/deploy",
     tags=["config"],
     response_model=DeployResponse,
+    operation_id="legacy_yaml_deploy",
     summary="Deploy a pipeline from YAML definition (Not Maintained)",
     description=(
         "[DEPRECATED] This route is no longer maintained and will be removed in a future version. "
@@ -86,6 +87,7 @@ async def deploy(pipeline_def: PipelineDefinition, request: Request):
 @router.post(
     "/deploy_files",
     tags=["config"],
+    operation_id="pipeline_deploy",
     response_model=DeployResponse,
     summary="Deploy a pipeline from files (`pipeline_wrapper.py` and other files)",
     description=(

--- a/src/hayhooks/server/routers/deploy.py
+++ b/src/hayhooks/server/routers/deploy.py
@@ -59,6 +59,8 @@ class PipelineFilesRequest(BaseModel):
 
 class DeployResponse(BaseModel):
     name: str = Field(description="Name of the deployed pipeline")
+    success: bool = Field(default=True, description="Whether the deployment was successful")
+    endpoint: str = Field(description="Endpoint of the deployed pipeline")
 
     model_config = {"json_schema_extra": {"description": "Response model for pipeline deployment operations"}}
 
@@ -78,7 +80,7 @@ class DeployResponse(BaseModel):
 )
 async def deploy(pipeline_def: PipelineDefinition, request: Request):
     result = deploy_pipeline_def(request.app, pipeline_def)
-    return DeployResponse(name=result["name"])
+    return DeployResponse(name=result["name"], success=True, endpoint=f"/{result['name']}/run")
 
 
 @router.post(
@@ -100,7 +102,7 @@ async def deploy_files(pipeline_files_request: PipelineFilesRequest, request: Re
             save_files=pipeline_files_request.save_files,
             overwrite=pipeline_files_request.overwrite,
         )
-        return DeployResponse(name=result["name"])
+        return DeployResponse(name=result["name"], success=True, endpoint=f"/{result['name']}/run")
     except PipelineFilesError as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
     except PipelineModuleLoadError as e:

--- a/src/hayhooks/server/routers/draw.py
+++ b/src/hayhooks/server/routers/draw.py
@@ -1,6 +1,6 @@
 import tempfile
 from pathlib import Path
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Path as PathParam
 from fastapi.responses import FileResponse
 from hayhooks.server.pipelines import registry
 from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
@@ -8,15 +8,27 @@ from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
 router = APIRouter()
 
 
-@router.get("/draw/{pipeline_name}", tags=["config"])
-async def draw(pipeline_name):
+@router.get(
+    "/draw/{pipeline_name}",
+    tags=["config"],
+    summary="Generate a pipeline diagram",
+    description="Returns a PNG image visualization of the specified pipeline. Returns 404 if the pipeline doesn't exist.",
+    response_class=FileResponse,
+    responses={
+        200: {"content": {"image/png": {}}, "description": "A PNG visualization of the pipeline graph"},
+        404: {"description": "Pipeline not found"},
+    },
+)
+async def draw(
+    pipeline_name: str = PathParam(description="Name of the pipeline to visualize", examples=["my_pipeline"])
+):
     pipeline = registry.get(pipeline_name)
 
     if isinstance(pipeline, BasePipelineWrapper):
         pipeline = pipeline.pipeline
 
     if not pipeline:
-        raise HTTPException(status_code=404)
+        raise HTTPException(status_code=404, detail=f"Pipeline '{pipeline_name}' not found")
 
     _, fpath = tempfile.mkstemp()
     pipeline.draw(Path(fpath))

--- a/src/hayhooks/server/routers/draw.py
+++ b/src/hayhooks/server/routers/draw.py
@@ -11,6 +11,7 @@ router = APIRouter()
 @router.get(
     "/draw/{pipeline_name}",
     tags=["config"],
+    operation_id="pipeline_draw",
     summary="Generate a pipeline diagram",
     description="Returns a PNG image visualization of the specified pipeline. Returns 404 if the pipeline doesn't exist.",
     response_class=FileResponse,

--- a/src/hayhooks/server/routers/openai.py
+++ b/src/hayhooks/server/routers/openai.py
@@ -56,8 +56,8 @@ class ChatCompletion(OpenAIBaseModel):
     choices: List[Choice]
 
 
-@router.get("/v1/models", response_model=ModelsResponse)
-@router.get("/models", response_model=ModelsResponse)
+@router.get("/v1/models", response_model=ModelsResponse, tags=["openai"])
+@router.get("/models", response_model=ModelsResponse, tags=["openai"])
 async def get_models():
     """
     Implementation of OpenAI /models endpoint.
@@ -86,9 +86,9 @@ async def get_models():
     )
 
 
-@router.post("/v1/chat/completions", response_model=ChatCompletion)
-@router.post("/chat/completions", response_model=ChatCompletion)
-@router.post("/{pipeline_name}/chat", response_model=ChatCompletion)
+@router.post("/v1/chat/completions", response_model=ChatCompletion, tags=["openai"])
+@router.post("/chat/completions", response_model=ChatCompletion, tags=["openai"])
+@router.post("/{pipeline_name}/chat", response_model=ChatCompletion, tags=["openai"])
 @handle_pipeline_exceptions()
 async def chat_endpoint(chat_req: ChatRequest) -> Union[ChatCompletion, StreamingResponse]:
     pipeline_wrapper = registry.get(chat_req.model)

--- a/src/hayhooks/server/routers/openai.py
+++ b/src/hayhooks/server/routers/openai.py
@@ -56,8 +56,15 @@ class ChatCompletion(OpenAIBaseModel):
     choices: List[Choice]
 
 
-@router.get("/v1/models", response_model=ModelsResponse, tags=["openai"])
-@router.get("/models", response_model=ModelsResponse, tags=["openai"])
+MODELS_PARAMS: dict = {
+    "response_model": ModelsResponse,
+    "tags": ["openai"],
+    "operation_id": "openai_models",
+}
+
+
+@router.get("/v1/models", **MODELS_PARAMS)
+@router.get("/models", **MODELS_PARAMS)
 async def get_models():
     """
     Implementation of OpenAI /models endpoint.
@@ -86,9 +93,16 @@ async def get_models():
     )
 
 
-@router.post("/v1/chat/completions", response_model=ChatCompletion, tags=["openai"])
-@router.post("/chat/completions", response_model=ChatCompletion, tags=["openai"])
-@router.post("/{pipeline_name}/chat", response_model=ChatCompletion, tags=["openai"])
+CHAT_COMPLETION_PARAMS: dict = {
+    "response_model": ChatCompletion,
+    "tags": ["openai"],
+    "operation_id": "openai_chat_completions",
+}
+
+
+@router.post("/v1/chat/completions", **CHAT_COMPLETION_PARAMS)
+@router.post("/chat/completions", **CHAT_COMPLETION_PARAMS)
+@router.post("/{pipeline_name}/chat", **CHAT_COMPLETION_PARAMS)
 @handle_pipeline_exceptions()
 async def chat_endpoint(chat_req: ChatRequest) -> Union[ChatCompletion, StreamingResponse]:
     pipeline_wrapper = registry.get(chat_req.model)

--- a/src/hayhooks/server/routers/openai.py
+++ b/src/hayhooks/server/routers/openai.py
@@ -59,12 +59,11 @@ class ChatCompletion(OpenAIBaseModel):
 MODELS_PARAMS: dict = {
     "response_model": ModelsResponse,
     "tags": ["openai"],
-    "operation_id": "openai_models",
 }
 
 
-@router.get("/v1/models", **MODELS_PARAMS)
-@router.get("/models", **MODELS_PARAMS)
+@router.get("/v1/models", **MODELS_PARAMS, operation_id="openai_models")
+@router.get("/models", **MODELS_PARAMS, operation_id="openai_models_alias")
 async def get_models():
     """
     Implementation of OpenAI /models endpoint.
@@ -96,13 +95,12 @@ async def get_models():
 CHAT_COMPLETION_PARAMS: dict = {
     "response_model": ChatCompletion,
     "tags": ["openai"],
-    "operation_id": "openai_chat_completions",
 }
 
 
-@router.post("/v1/chat/completions", **CHAT_COMPLETION_PARAMS)
-@router.post("/chat/completions", **CHAT_COMPLETION_PARAMS)
-@router.post("/{pipeline_name}/chat", **CHAT_COMPLETION_PARAMS)
+@router.post("/chat/completions", **CHAT_COMPLETION_PARAMS, operation_id="openai_chat_completions")
+@router.post("/v1/chat/completions", **CHAT_COMPLETION_PARAMS, operation_id="openai_chat_completions_alias")
+@router.post("/{pipeline_name}/chat", **CHAT_COMPLETION_PARAMS, operation_id="chat_completions")
 @handle_pipeline_exceptions()
 async def chat_endpoint(chat_req: ChatRequest) -> Union[ChatCompletion, StreamingResponse]:
     pipeline_wrapper = registry.get(chat_req.model)

--- a/src/hayhooks/server/routers/status.py
+++ b/src/hayhooks/server/routers/status.py
@@ -26,6 +26,7 @@ class PipelineStatusResponse(BaseModel):
     "/status",
     tags=["status"],
     response_model=StatusResponse,
+    operation_id="status_all",
     summary="Get status of all pipelines",
     description="Returns the system status and a list of all available pipelines.",
 )
@@ -38,6 +39,7 @@ async def status_all():
     "/status/{pipeline_name}",
     tags=["status"],
     response_model=PipelineStatusResponse,
+    operation_id="status_pipeline",
     summary="Get status of a specific pipeline",
     description="Returns the status of a specific pipeline. Returns 404 if the pipeline doesn't exist.",
 )

--- a/src/hayhooks/server/routers/undeploy.py
+++ b/src/hayhooks/server/routers/undeploy.py
@@ -18,6 +18,7 @@ class UndeployResponse(BaseModel):
 @router.post(
     "/undeploy/{pipeline_name}",
     tags=["config"],
+    operation_id="pipeline_undeploy",
     response_model=UndeployResponse,
     summary="Undeploy a pipeline",
     description="Removes a pipeline from the registry, removes its API routes and deletes its files from disk.",

--- a/src/hayhooks/settings.py
+++ b/src/hayhooks/settings.py
@@ -7,6 +7,10 @@ from hayhooks.server.logger import log
 load_dotenv(dotenv_path=find_dotenv(usecwd=True))
 
 
+APP_TITLE = "Hayhooks"
+APP_DESCRIPTION = "Hayhooks makes it easy to deploy and serve Haystack pipelines as REST APIs or MCP Tools"
+
+
 class AppSettings(BaseSettings):
     # Root path for the FastAPI app
     root_path: str = ""

--- a/tests/test_it_deploy_files.py
+++ b/tests/test_it_deploy_files.py
@@ -1,6 +1,6 @@
-from fastapi.testclient import TestClient
 import pytest
 import shutil
+from hayhooks.server.routers.deploy import DeployResponse
 from pathlib import Path
 from hayhooks.server.pipelines.registry import registry
 
@@ -41,7 +41,10 @@ def test_deploy_files_ok(status_pipeline, pipeline_files, client, deploy_files):
 
     response = deploy_files(client, pipeline_name=pipeline_data["name"], pipeline_files=pipeline_data["files"])
     assert response.status_code == 200
-    assert response.json() == {"name": pipeline_files[0]}
+    assert (
+        response.json()
+        == DeployResponse(name=pipeline_files[0], success=True, endpoint=f"/{pipeline_files[0]}/run").model_dump()
+    )
 
     status_response = status_pipeline(client, pipeline_files[0])
     assert pipeline_files[0] in status_response.json()["pipeline"]

--- a/tests/test_it_deploy_files.py
+++ b/tests/test_it_deploy_files.py
@@ -61,7 +61,6 @@ def test_deploy_files_ok(status_pipeline, pipeline_files, client, deploy_files):
             f"/{pipeline_data['name']}/run",
             json={"urls": ["https://www.redis.io"], "question": "What is Redis?"},
         )
-        print(response.json())
         assert response.status_code == 200
         assert response.json() == {"result": "This is a mock response from the pipeline"}
 
@@ -70,7 +69,6 @@ def test_deploy_files_ok(status_pipeline, pipeline_files, client, deploy_files):
             f"/{pipeline_data['name']}/run",
             json={"test_param": "test_value"},
         )
-        print(response.json())
         assert response.status_code == 200
         assert response.json() == {"result": "Dummy result with test_value"}
 

--- a/tests/test_it_deploy_files.py
+++ b/tests/test_it_deploy_files.py
@@ -78,7 +78,7 @@ def test_deploy_files_missing_wrapper(client, deploy_files):
 
     response = deploy_files(client, pipeline_name=pipeline_data["name"], pipeline_files=pipeline_data["files"])
     assert response.status_code == 422
-    assert "Required file" in response.json()["detail"]
+    assert "Missing required file" in response.json()["detail"][0]["msg"]
 
 
 def test_deploy_files_invalid_wrapper(client, deploy_files):

--- a/tests/test_it_openai.py
+++ b/tests/test_it_openai.py
@@ -1,5 +1,6 @@
 import json
 import shutil
+from hayhooks.server.routers.deploy import DeployResponse
 import pytest
 from concurrent.futures import ThreadPoolExecutor
 from hayhooks.settings import settings
@@ -58,7 +59,10 @@ def test_get_models(client):
 
     response = client.post("/deploy_files", json=pipeline_data)
     assert response.status_code == 200
-    assert response.json() == {"name": "test_pipeline"}
+    assert (
+        response.json()
+        == DeployResponse(name="test_pipeline", success=True, endpoint=f"/{pipeline_data['name']}/run").model_dump()
+    )
 
     response = client.get("/models")
     response_data = response.json()
@@ -85,7 +89,10 @@ def test_chat_completion_success(client, deploy_files):
 
     response = deploy_files(client, pipeline_data["name"], pipeline_data["files"])
     assert response.status_code == 200
-    assert response.json() == {"name": "test_pipeline"}
+    assert (
+        response.json()
+        == DeployResponse(name="test_pipeline", success=True, endpoint=f"/{pipeline_data['name']}/run").model_dump()
+    )
 
     # This is a sample request coming from openai-webui
     request = ChatRequest(
@@ -125,7 +132,12 @@ def test_chat_completion_not_implemented(client, deploy_files):
 
     response = deploy_files(client, pipeline_data["name"], pipeline_data["files"])
     assert response.status_code == 200
-    assert response.json() == {"name": "test_pipeline_no_chat"}
+    assert (
+        response.json()
+        == DeployResponse(
+            name="test_pipeline_no_chat", success=True, endpoint=f"/{pipeline_data['name']}/run"
+        ).model_dump()
+    )
 
     request = ChatRequest(model="test_pipeline_no_chat", messages=[{"role": "user", "content": "Hello"}])
 
@@ -139,7 +151,12 @@ def test_chat_completion_streaming(client, deploy_files):
 
     response = deploy_files(client, pipeline_data["name"], pipeline_data["files"])
     assert response.status_code == 200
-    assert response.json() == {"name": "test_pipeline_streaming"}
+    assert (
+        response.json()
+        == DeployResponse(
+            name="test_pipeline_streaming", success=True, endpoint=f"/{pipeline_data['name']}/run"
+        ).model_dump()
+    )
 
     request = ChatRequest(
         model="test_pipeline_streaming",
@@ -184,7 +201,12 @@ def test_chat_completion_concurrent_requests(client, deploy_files):
 
     response = deploy_files(client, pipeline_data["name"], pipeline_data["files"])
     assert response.status_code == 200
-    assert response.json() == {"name": "test_pipeline_streaming"}
+    assert (
+        response.json()
+        == DeployResponse(
+            name="test_pipeline_streaming", success=True, endpoint=f"/{pipeline_data['name']}/run"
+        ).model_dump()
+    )
 
     request_1 = ChatRequest(model="test_pipeline_streaming", messages=[{"role": "user", "content": "what is Redis?"}])
     request_2 = ChatRequest(model="test_pipeline_streaming", messages=[{"role": "user", "content": "what is MongoDB?"}])

--- a/tests/test_undeploy.py
+++ b/tests/test_undeploy.py
@@ -34,7 +34,6 @@ def test_undeploy_standard_pipeline(client: TestClient, deploy_pipeline, undeplo
 
     # Verify pipeline endpoint no longer exists
     response = client.post(f"/test_undeploy_pipeline", json={})
-    print(response.json())
     assert response.status_code == 404
 
 


### PR DESCRIPTION
TL;DR

This PR doesn't add any new feature, but rather improve generated OpenAPI / Swagger / Redocly documentation in order to ease the use of Hayhooks as an [OpenAPI Tool Server](https://docs.openwebui.com/openapi-servers/).

---

In order to enhance usare of Hayhooks as an [OpenAPI Tool Server by Open WebUI](https://docs.openwebui.com/openapi-servers/open-webui), we need to have a more description app title, description and version. 

Also, every Pydantic model needs to be better documented, possibly with examples.

This way it will be possible to use the entire Hayhooks as a Tool, so an agent could run / deploy / check pipelines. I'll plan to exposes the functionalities for MCP Server too.

This basically leads to a **far better** open-webui integration than acting like an open-webui backend.

![Screenshot 2025-04-04 at 14 35 28](https://github.com/user-attachments/assets/0ad9c785-7b4c-4321-85c6-4048a388751d)

![Screenshot 2025-04-04 at 15 56 00](https://github.com/user-attachments/assets/d4a8b686-28d2-4811-a5dd-7c9ce40f9ccb)
