### PR TITLE
Improve `run_api` dynamic schema creation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,9 @@ A [MCP Tool](https://modelcontextprotocol.io/docs/concepts/tools) requires the f
 For each deployed pipeline, Hayhooks will:
 
 - Use the pipeline wrapper `name` as MCP Tool `name` (always present).
-- Use the pipeline wrapper **`run_api` method docstring** as MCP Tool `description` (if present).
+- Parse **`run_api` method docstring**:
+  - If you use Google-style or reStructuredText-style docstrings, use the first line as MCP Tool `description` and the rest as `parameters` (if present).
+  - Each parameter description will be used as the `description` of the corresponding Pydantic model field (if present).
 - Generate a Pydantic model from the `inputSchema` using the **`run_api` method arguments as fields**.
 
 Here's an example of a PipelineWrapper implementation for the `chat_with_website` pipeline which can be used as a MCP Tool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ extra-dependencies = [
   "trafilatura",
   "pytest-asyncio",
   "mcp ; python_version >= '3.10'",
+  "docstring-parser",
 ]
 
 [[tool.hatch.envs.all.matrix]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "loguru",
   "pydantic-settings",
   "python-dotenv",
+  "docstring-parser",
 ]
 
 [project.optional-dependencies]
@@ -79,7 +80,6 @@ extra-dependencies = [
   "trafilatura",
   "pytest-asyncio",
   "mcp ; python_version >= '3.10'",
-  "docstring-parser",
 ]
 
 [[tool.hatch.envs.all.matrix]]

--- a/src/hayhooks/server/utils/deploy_utils.py
+++ b/src/hayhooks/server/utils/deploy_utils.py
@@ -197,7 +197,7 @@ def create_request_model_from_callable(func: Callable, model_name: str, docstrin
     fields: Dict[str, Any] = {}
     for name, param in params.items():
         default_value = ... if param.default == param.empty else param.default
-        description = param_docs.get(name)
+        description = param_docs.get(name) or f"Parameter '{name}'"
         field_info = Field(default=default_value, description=description)
         fields[name] = (param.annotation, field_info)
 

--- a/tests/test_deploy_utils.py
+++ b/tests/test_deploy_utils.py
@@ -1,5 +1,7 @@
 import pytest
 import shutil
+import docstring_parser
+import inspect
 from fastapi.routing import APIRoute
 from hayhooks.server.pipelines import registry
 from haystack import Pipeline
@@ -115,7 +117,8 @@ def test_create_request_model_from_callable():
         """
         pass
 
-    model = create_request_model_from_callable(sample_func, "Test")
+    docstring = docstring_parser.parse(inspect.getdoc(sample_func) or "")
+    model = create_request_model_from_callable(sample_func, "Test", docstring)
     schema = model.model_json_schema()
 
     assert model.__name__ == "TestRequest"
@@ -139,7 +142,8 @@ def test_create_request_model_no_docstring():
     def sample_func_no_doc(name: str, age: int = 30):
         pass
 
-    model = create_request_model_from_callable(sample_func_no_doc, "NoDoc")
+    docstring = docstring_parser.parse(inspect.getdoc(sample_func_no_doc) or "")
+    model = create_request_model_from_callable(sample_func_no_doc, "NoDoc", docstring)
     schema = model.model_json_schema()
 
     assert model.__name__ == "NoDocRequest"
@@ -161,7 +165,8 @@ def test_create_response_model_from_callable():
         """
         return {"result": "test"}
 
-    model = create_response_model_from_callable(sample_func, "Test")
+    docstring = docstring_parser.parse(inspect.getdoc(sample_func) or "")
+    model = create_response_model_from_callable(sample_func, "Test", docstring)
     schema = model.model_json_schema()
 
     assert model.__name__ == "TestResponse"
@@ -175,7 +180,8 @@ def test_create_response_model_no_docstring():
     def sample_func_no_doc() -> int:
         return 1
 
-    model = create_response_model_from_callable(sample_func_no_doc, "NoDoc")
+    docstring = docstring_parser.parse(inspect.getdoc(sample_func_no_doc) or "")
+    model = create_response_model_from_callable(sample_func_no_doc, "NoDoc", docstring)
     schema = model.model_json_schema()
 
     assert model.__name__ == "NoDocResponse"

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -57,8 +57,8 @@ async def test_list_pipelines_as_tools(deploy_chat_with_website_mcp):
     assert tools[0].description == "Ask a question about one or more websites using a Haystack pipeline."
     assert tools[0].inputSchema == {
         'properties': {
-            'urls': {'items': {'type': 'string'}, 'title': 'Urls', 'type': 'array'},
-            'question': {'title': 'Question', 'type': 'string'},
+            'urls': {'items': {'type': 'string'}, 'title': 'Urls', 'type': 'array', 'description': "Parameter 'urls'"},
+            'question': {'title': 'Question', 'type': 'string', 'description': "Parameter 'question'"},
         },
         'required': ['urls', 'question'],
         'title': 'chat_with_websiteRunRequest',


### PR DESCRIPTION
This will add better description of `run_api` params / return type to dynamically create request / response pydantic models using [docstring_parser](https://github.com/rr-/docstring_parser) to automatically parse `run_api` docstring.

For example, if you have a `run_api` like:

```python
def run_api(question: str, urls: List[str]) -> str:
    """
    Ask a question about one or more websites using a Haystack pipeline.

    Args:
        question: The question to ask.
        urls: List of URLs to fetch.
        
    Returns:
        The answer to the question.
    """
    ...
```

It will add proper description, defaults (if present) and type to each param on pydantic model schema for `question`, `urls` and the return type. 

This improved description will improve Hayhooks usage as OpenAPI Tool or MCP Tool.