### PR TITLE
Improve `make_request` and `get_server_url` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The following environment variables are supported:
 - `HAYHOOKS_ROOT_PATH`: The root path of the server.
 - `HAYHOOKS_ADDITIONAL_PYTHONPATH`: Additional Python path to be added to the Python path.
 - `HAYHOOKS_DISABLE_SSL`: Boolean flag to disable SSL verification when making requests from the CLI.
+- `HAYHOOKS_USE_HTTPS`: Boolean flag to use HTTPS when using CLI commands to interact with the server (e.g. `hayhooks status` will call `https://HAYHOOKS_HOST:HAYHOOKS_PORT/status`).
 - `HAYHOOKS_SHOW_TRACEBACKS`: Boolean flag to show tracebacks on errors during pipeline execution and deployment.
 - `LOG`: The log level to use (default: `INFO`).
 
@@ -362,8 +363,10 @@ hayhooks mcp run
 This will start the Hayhooks MCP server on `HAYHOOKS_MCP_HOST:HAYHOOKS_MCP_PORT`.
 
 ### Using Hayhooks MCP Server with Claude Desktop
+
 Claude Desktop doesn’t yet support SSE transport for MCP servers, so you’ll need to use [supergateway](https://github.com/supercorp-ai/supergateway).
 After starting the Hayhooks MCP server, open **Settngs → Developer** in Claude Desktop and update the config file like this:
+
 ```json
 {
   "mcpServers": {
@@ -379,6 +382,7 @@ After starting the Hayhooks MCP server, open **Settngs → Developer** in Claude
   }
 }
 ```
+
 Make sure [Node.js](https://nodejs.org/) is installed, as the `npx` command depends on it.
 
 ### Create a PipelineWrapper for exposing a Haystack pipeline as a MCP Tool

--- a/src/hayhooks/cli/base.py
+++ b/src/hayhooks/cli/base.py
@@ -64,11 +64,15 @@ def run(
 def status(ctx: typer.Context):
     """Get the status of the Hayhooks server."""
     response = make_request(
-        host=ctx.obj["host"], port=ctx.obj["port"], endpoint="status", disable_ssl=ctx.obj["disable_ssl"]
+        host=ctx.obj["host"],
+        port=ctx.obj["port"],
+        endpoint="status",
+        use_https=ctx.obj["use_https"],
+        disable_ssl=ctx.obj["disable_ssl"]
     )
 
     show_success_panel(
-        f"[bold]Hayhooks server is up and running at: {get_server_url(ctx.obj['host'], ctx.obj['port'])}[/bold]",
+        f"[bold]Hayhooks server is up and running at: {get_server_url(ctx.obj['host'], ctx.obj['port'], https=ctx.obj['use_https'])}",
         title="",
     )
 
@@ -91,7 +95,8 @@ def status(ctx: typer.Context):
 @hayhooks_cli.callback()
 def callback(ctx: typer.Context):
     ctx.obj = {
-        "disable_ssl": settings.disable_ssl,
         "host": settings.host,
         "port": settings.port,
+        "disable_ssl": settings.disable_ssl,
+        "use_https": settings.use_https,
     }

--- a/src/hayhooks/cli/pipeline.py
+++ b/src/hayhooks/cli/pipeline.py
@@ -28,6 +28,7 @@ def _deploy_with_progress(ctx: typer.Context, name: str, endpoint: str, payload:
         endpoint=endpoint,
         method="POST",
         json=payload,
+        use_https=ctx.obj["use_https"],
         disable_ssl=ctx.obj["disable_ssl"],
     )
 
@@ -96,6 +97,7 @@ def undeploy(
         port=ctx.obj["port"],
         endpoint=f"undeploy/{name}",
         method="POST",
+        use_https=ctx.obj["use_https"],
         disable_ssl=ctx.obj["disable_ssl"],
     )
 
@@ -217,6 +219,7 @@ def run_pipeline_with_files(
             method="POST",
             json=params,
             disable_ssl=ctx.obj["disable_ssl"],
+            use_https=ctx.obj["use_https"],
         )
         result = response
 

--- a/src/hayhooks/cli/utils.py
+++ b/src/hayhooks/cli/utils.py
@@ -34,6 +34,7 @@ def make_request(
     endpoint: str,
     method: str = "GET",
     json: Optional[Dict[str, Any]] = None,
+    use_https: bool = False,
     disable_ssl: bool = False,
 ) -> Dict[str, Any]:
     """Make HTTP request to Hayhooks server with error handling.
@@ -44,9 +45,10 @@ def make_request(
         endpoint: API endpoint path
         method: HTTP method (GET, POST, etc)
         json: Optional JSON payload
-        disable_ssl: Whether to disable SSL verification
+        use_https: Whether to use HTTPS for the connection.
+        disable_ssl: Whether to disable SSL certificate verification.
     """
-    server_url = get_server_url(host, port, disable_ssl)
+    server_url = get_server_url(host, port, https=use_https)
     url = urljoin(server_url, endpoint)
 
     try:

--- a/src/hayhooks/settings.py
+++ b/src/hayhooks/settings.py
@@ -28,6 +28,11 @@ class AppSettings(BaseSettings):
     # Port for the FastAPI app
     port: int = 1416
 
+    # Whether to use HTTPS when running CLI commands
+    # Example: `hayhooks status`
+    # NOTE: This is NOT used to specify the protocol for the uvicorn server
+    use_https: bool = False
+
     # Host for the MCP app
     mcp_host: str = "localhost"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,133 @@
+import pytest
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock
+from requests import ConnectionError, HTTPError, JSONDecodeError
+from hayhooks.cli.utils import make_request, get_server_url
+
+
+@pytest.fixture
+def mock_requests(monkeypatch):
+    mock = MagicMock()
+    monkeypatch.setattr("hayhooks.cli.utils.requests.request", mock)
+    return mock
+
+
+def configure_mock_response(
+    mock_requests, *, json_return_value: Dict[str, Any] = {}, raise_return_value: Optional[Exception] = None
+):
+    mock_response = MagicMock()
+    mock_response.json.return_value = json_return_value
+
+    if isinstance(raise_return_value, Exception):
+        mock_response.raise_for_status.side_effect = raise_return_value
+    else:
+        mock_response.raise_for_status.return_value = raise_return_value
+    mock_requests.return_value = mock_response
+
+    return mock_response
+
+
+def test_get_server_url():
+    assert get_server_url("localhost", 8000) == "http://localhost:8000"
+    assert get_server_url("localhost", 8000, https=False) == "http://localhost:8000"
+    assert get_server_url("localhost", 8000, https=True) == "https://localhost:8000"
+
+
+def test_make_request_http_get_success(mock_requests):
+    configure_mock_response(mock_requests, json_return_value={"status": "ok"})
+
+    response = make_request("localhost", 8000, "/test_endpoint")
+
+    mock_requests.assert_called_once_with(
+        method="GET",
+        url="http://localhost:8000/test_endpoint",
+        json=None,
+        verify=True,
+    )
+    assert response == {"status": "ok"}
+
+
+def test_make_request_https_success(mock_requests):
+    configure_mock_response(mock_requests, json_return_value={"status": "ok_https"})
+
+    response = make_request("localhost", 8000, "/secure_endpoint", use_https=True)
+
+    mock_requests.assert_called_once_with(
+        method="GET",
+        url="https://localhost:8000/secure_endpoint",
+        json=None,
+        verify=True,
+    )
+    assert response == {"status": "ok_https"}
+
+
+def test_make_request_https_disable_ssl_verification(mock_requests):
+    configure_mock_response(mock_requests, json_return_value={"status": "ok_https_noverify"})
+
+    response = make_request("localhost", 8000, "/secure_endpoint_noverify", use_https=True, disable_ssl=True)
+
+    mock_requests.assert_called_once_with(
+        method="GET",
+        url="https://localhost:8000/secure_endpoint_noverify",
+        json=None,
+        verify=False,
+    )
+    assert response == {"status": "ok_https_noverify"}
+
+
+def test_make_request_connection_error(mock_requests, capsys):
+    mock_requests.side_effect = ConnectionError("Test connection error")
+
+    with pytest.raises(Exception):
+        make_request("localhost", 8000, "/test_endpoint")
+
+    mock_requests.assert_called_once_with(
+        method="GET", url="http://localhost:8000/test_endpoint", json=None, verify=True
+    )
+    captured = capsys.readouterr()
+    assert "Hayhooks server is not responding." in captured.out
+    assert "To start one, run `hayhooks run`" in captured.out
+
+
+def test_make_request_http_error_with_detail(mock_requests, capsys):
+    http_error = HTTPError("404 Client Error")
+    mock_response = configure_mock_response(
+        mock_requests, json_return_value={"detail": "Item not found"}, raise_return_value=http_error
+    )
+    http_error.response = mock_response
+
+    with pytest.raises(Exception):
+        make_request("localhost", 8000, "/notfound")
+
+    mock_requests.assert_called_once_with(method="GET", url="http://localhost:8000/notfound", json=None, verify=True)
+    captured = capsys.readouterr()
+    assert "Server error" in captured.out
+    assert "Item not found" in captured.out
+
+
+def test_make_request_http_error_no_detail(mock_requests, capsys):
+    http_error = HTTPError("500 Server Error")
+    mock_response = configure_mock_response(mock_requests, json_return_value={}, raise_return_value=http_error)
+    http_error.response = mock_response
+
+    with pytest.raises(Exception):
+        make_request("localhost", 8000, "/servererror")
+
+    mock_requests.assert_called_once_with(method="GET", url="http://localhost:8000/servererror", json=None, verify=True)
+    captured = capsys.readouterr()
+    assert "Server error" in captured.out
+    assert "Unknown error" in captured.out  # Default message
+
+
+def test_make_request_unexpected_error(mock_requests, capsys):
+    mock_requests.side_effect = Exception("Something totally unexpected")
+
+    with pytest.raises(Exception):
+        make_request("localhost", 8000, "/test_endpoint")
+
+    mock_requests.assert_called_once_with(
+        method="GET", url="http://localhost:8000/test_endpoint", json=None, verify=True
+    )
+    captured = capsys.readouterr()
+    assert "Unexpected error" in captured.out
+    assert "Something totally unexpected" in captured.out


### PR DESCRIPTION
This fixed #112.

I've took the chance to actually improve the logic and introduce an additional `use_https` params in `make_request`. This because current logic is a bit tangled: the `disable_ssl` flag was trying to influence both the URL scheme (HTTP/HTTPS) and TLS/SSL certificate verification, which leads to incorrect behaviour in several scenarios.

With this we introduce `HAYHOOKS_USE_HTTPS` settings (documented in README) which will make CLI to actually use HTTPS or not, while `disable_ssl` simply skip TLS/SSL certificate verification (as it should be).