### PR TITLE
Core Hayhooks MCP Tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ extra-dependencies = [
   "mcp ; python_version >= '3.10'",
 ]
 
-[[tool.hatch.envs.all.matrix]]
+[[tool.hatch.envs.test.matrix]]
 python = ["3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,9 +82,6 @@ extra-dependencies = [
   "mcp ; python_version >= '3.10'",
 ]
 
-[[tool.hatch.envs.test.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12"]
-
 [tool.hatch.envs.lint]
 detached = true
 dependencies = [

--- a/src/hayhooks/cli/mcp.py
+++ b/src/hayhooks/cli/mcp.py
@@ -1,9 +1,18 @@
+import asyncio
 import typer
 import uvicorn
 import sys
 from typing import Annotated, List, Optional
+from hayhooks.server.pipelines import registry
+from hayhooks.server.utils.deploy_utils import deploy_pipeline_files, undeploy_pipeline
 from hayhooks.settings import settings
-from hayhooks.server.utils.mcp_utils import deploy_pipelines, list_pipelines_as_tools, run_pipeline_as_tool
+from hayhooks.server.utils.mcp_utils import (
+    CoreTools,
+    deploy_pipelines,
+    list_core_tools,
+    list_pipelines_as_tools,
+    run_pipeline_as_tool,
+)
 from hayhooks.server.logger import log
 from haystack.lazy_imports import LazyImport
 
@@ -51,7 +60,13 @@ def run(
     @server.list_tools()
     async def list_tools() -> List[Tool]:
         try:
-            return await list_pipelines_as_tools()
+            core_tools = await list_core_tools()
+            log.debug(f"Listing {len(core_tools)} core tools")
+
+            pipelines_tools = await list_pipelines_as_tools()
+            log.debug(f"Listing {len(pipelines_tools)} pipelines as tools")
+
+            return core_tools + pipelines_tools
         except Exception as e:
             log.error(f"Error listing tools: {e}")
             return []
@@ -59,10 +74,50 @@ def run(
     @server.call_tool()
     async def call_tool(name: str, arguments: dict) -> List[TextContent | ImageContent | EmbeddedResource]:
         try:
-            return await run_pipeline_as_tool(name, arguments)
-        except Exception as e:
-            log.error(f"Error calling tool: {e}")
-            return []
+            if name == CoreTools.DEPLOY_PIPELINE:
+                result = await asyncio.to_thread(
+                    deploy_pipeline_files,
+                    pipeline_name=arguments["name"],
+                    files=arguments["files"],
+                    app=None,
+                    save_files=arguments["save_files"],
+                    overwrite=arguments["overwrite"],
+                )
+                return [TextContent(type="text", text=f"Pipeline '{result['name']}' deployed successfully")]
+
+            elif name == CoreTools.GET_ALL_PIPELINE_STATUSES:
+                pipelines = registry.get_names()
+                return [TextContent(type="text", text=f"Available pipelines:\\n{'\n'.join(pipelines)}")]
+
+            elif name == CoreTools.GET_PIPELINE_STATUS:
+                pipeline_name = arguments["pipeline_name"]
+                is_deployed = pipeline_name in registry.get_names()
+                return [TextContent(type="text", text=f"Pipeline '{pipeline_name}' is deployed: {is_deployed}")]
+
+            elif name == CoreTools.UNDEPLOY_PIPELINE:
+                pipeline_name = arguments["pipeline_name"]
+                undeploy_pipeline(pipeline_name=pipeline_name)
+                return [TextContent(type="text", text=f"Pipeline '{pipeline_name}' undeployed")]
+
+            else:
+                log.debug(f"Attempting to run tool '{name}' as a pipeline with arguments: {arguments}")
+                try:
+                    return await run_pipeline_as_tool(name, arguments)
+                except Exception as e_pipeline:
+                    log.error(f"Error calling pipeline tool '{name}': {e_pipeline}")
+                    return []
+
+        except KeyError as e_args:
+            log.error(f"Missing argument for tool '{name}': {e_args}")
+            return [TextContent(type="text", text=f"Error calling tool '{name}': Missing argument {e_args}.")]
+
+        except Exception as e_general:
+            log.error(f"General unhandled error in call_tool for tool '{name}': {e_general}")
+            return [
+                TextContent(
+                    type="text", text=f"An unexpected error occurred while processing tool '{name}': {e_general}."
+                )
+            ]
 
     # Setup the SSE server
     sse = SseServerTransport("/messages/")

--- a/src/hayhooks/cli/mcp.py
+++ b/src/hayhooks/cli/mcp.py
@@ -87,7 +87,8 @@ def run(
 
             elif name == CoreTools.GET_ALL_PIPELINE_STATUSES:
                 pipelines = registry.get_names()
-                return [TextContent(type="text", text=f"Available pipelines:\\n{'\n'.join(pipelines)}")]
+                pipelines_str = "\n".join(pipelines)
+                return [TextContent(type="text", text=f"Available pipelines:\n{pipelines_str}")]
 
             elif name == CoreTools.GET_PIPELINE_STATUS:
                 pipeline_name = arguments["pipeline_name"]

--- a/src/hayhooks/server/routers/undeploy.py
+++ b/src/hayhooks/server/routers/undeploy.py
@@ -1,9 +1,6 @@
-from fastapi import APIRouter, HTTPException, Request, Path
-from fastapi.routing import APIRoute
+from fastapi import APIRouter, Request, Path
 from pydantic import BaseModel, Field
-from hayhooks.server.pipelines import registry
-from hayhooks.server.utils.deploy_utils import remove_pipeline_files
-from hayhooks.settings import settings
+from hayhooks.server.utils.deploy_utils import undeploy_pipeline
 
 router = APIRouter()
 
@@ -28,21 +25,5 @@ async def undeploy(
     request: Request,
     pipeline_name: str = Path(description="Name of the pipeline to undeploy", examples=["my_pipeline"]),
 ):
-    # Check if pipeline exists in registry
-    if pipeline_name not in registry.get_names():
-        raise HTTPException(status_code=404, detail=f"Pipeline '{pipeline_name}' not found")
-
-    # Remove pipeline from registry
-    registry.remove(pipeline_name)
-
-    # Remove API routes for the pipeline
-    # YAML based pipelines have a run endpoint at /<pipeline_name>
-    # Wrapper based pipelines have a run endpoint at /<pipeline_name>/run
-    for route in request.app.routes:
-        if isinstance(route, APIRoute) and (route.path == f"/{pipeline_name}/run" or route.path == f"/{pipeline_name}"):
-            request.app.routes.remove(route)
-
-    # Remove pipeline files if they exist
-    remove_pipeline_files(pipeline_name, settings.pipelines_dir)
-
+    undeploy_pipeline(pipeline_name, request.app)
     return UndeployResponse(success=True, name=pipeline_name)

--- a/src/hayhooks/server/utils/deploy_utils.py
+++ b/src/hayhooks/server/utils/deploy_utils.py
@@ -9,7 +9,7 @@ from docstring_parser.common import Docstring
 from functools import wraps
 from pathlib import Path
 from types import ModuleType
-from typing import Callable, Union, Any, Dict
+from typing import Callable, Union, Any, Dict, Optional
 from fastapi import FastAPI, Form, HTTPException
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse
@@ -324,19 +324,27 @@ def add_pipeline_api_route(app: FastAPI, pipeline_name: str, pipeline_wrapper: B
 
 
 def deploy_pipeline_files(
-    app: FastAPI, pipeline_name: str, files: dict[str, str], save_files: bool = True, overwrite: bool = False
+    pipeline_name: str,
+    files: dict[str, str],
+    app: Optional[FastAPI] = None,
+    save_files: bool = True,
+    overwrite: bool = False,
 ) -> dict[str, str]:
     """Deploy a pipeline.
 
-    This will add the pipeline to the registry and set up the API route.
+    This will add the pipeline to the registry and optionally set up the API route if `app` is provided.
 
     Args:
-        app: FastAPI application instance
         pipeline_name: Name of the pipeline to deploy
         files: Dictionary mapping filenames to their contents
+        app: Optional FastAPI application instance. If provided, the API route will be added.
+        save_files: Whether to save the pipeline files to disk
+        overwrite: Whether to overwrite an existing pipeline
     """
     pipeline_wrapper = add_pipeline_to_registry(pipeline_name, files, save_files, overwrite)
-    add_pipeline_api_route(app, pipeline_name, pipeline_wrapper)
+
+    if app:
+        add_pipeline_api_route(app, pipeline_name, pipeline_wrapper)
 
     return {"name": pipeline_name}
 

--- a/src/hayhooks/server/utils/mcp_utils.py
+++ b/src/hayhooks/server/utils/mcp_utils.py
@@ -144,11 +144,11 @@ async def run_pipeline_as_tool(
     return [TextContent(text=result, type="text")]
 
 
-async def notify_client(server: Server) -> None:
+async def notify_client(server: "Server") -> None:
     await server.request_context.session.send_tool_list_changed()
 
 
-async def create_mcp_server(name: str = "hayhooks-mcp-server") -> Server:
+async def create_mcp_server(name: str = "hayhooks-mcp-server") -> "Server":
     server: Server = Server(name)
 
     @server.list_tools()

--- a/src/hayhooks/server/utils/mcp_utils.py
+++ b/src/hayhooks/server/utils/mcp_utils.py
@@ -148,7 +148,7 @@ async def notify_client(server: "Server") -> None:
     await server.request_context.session.send_tool_list_changed()
 
 
-async def create_mcp_server(name: str = "hayhooks-mcp-server") -> "Server":
+def create_mcp_server(name: str = "hayhooks-mcp-server") -> "Server":
     server: Server = Server(name)
 
     @server.list_tools()

--- a/src/hayhooks/server/utils/mcp_utils.py
+++ b/src/hayhooks/server/utils/mcp_utils.py
@@ -200,14 +200,14 @@ def create_mcp_server(name: str = "hayhooks-mcp-server") -> "Server":
                 try:
                     return await run_pipeline_as_tool(name, arguments)
                 except Exception as e_pipeline:
-                    log.error(f"Error calling pipeline as MCP Tool '{name}': {e_pipeline}")
-                    return [TextContent(type="text", text=f"Error calling tool '{name}': {e_pipeline}")]
+                    msg = f"Error calling pipeline as MCP Tool '{name}': {e_pipeline}"
+                    log.error(msg)
+                    raise Exception(msg) from e_pipeline
 
         except Exception as exc:
-            log.error(f"General unhandled error in call_tool for tool '{name}': {exc}")
-            return [
-                TextContent(type="text", text=f"An unexpected error occurred while processing tool '{name}': {exc}.")
-            ]
+            msg = f"General unhandled error in call_tool for tool '{name}': {exc}"
+            log.error(msg)
+            raise Exception(msg) from exc
 
         finally:
             if name in [CoreTools.DEPLOY_PIPELINE, CoreTools.UNDEPLOY_PIPELINE]:

--- a/src/hayhooks/server/utils/mcp_utils.py
+++ b/src/hayhooks/server/utils/mcp_utils.py
@@ -5,11 +5,21 @@ from typing import TYPE_CHECKING, List, Union
 from hayhooks import log
 from hayhooks.server.app import init_pipeline_dir
 from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
-from hayhooks.server.utils.deploy_utils import add_pipeline_to_registry, read_pipeline_files_from_dir
+from hayhooks.server.utils.deploy_utils import (
+    add_pipeline_to_registry,
+    deploy_pipeline_files,
+    read_pipeline_files_from_dir,
+    undeploy_pipeline,
+)
 from hayhooks.settings import settings
 from hayhooks.server.pipelines import registry
 from haystack.lazy_imports import LazyImport
 from hayhooks.server.routers.deploy import PipelineFilesRequest
+
+
+with LazyImport("Run 'pip install \"mcp\"' to install MCP.") as mcp_import:
+    from mcp.types import Tool, TextContent, ImageContent, EmbeddedResource
+    from mcp.server import Server
 
 
 PIPELINE_NAME_SCHEMA = {
@@ -24,10 +34,6 @@ class CoreTools(str, Enum):
     GET_PIPELINE_STATUS = "get_pipeline_status"
     UNDEPLOY_PIPELINE = "undeploy_pipeline"
     DEPLOY_PIPELINE = "deploy_pipeline"
-
-    @classmethod
-    def has_value(cls, value):
-        return value in cls._value2member_map_
 
 
 if TYPE_CHECKING:
@@ -136,3 +142,76 @@ async def run_pipeline_as_tool(
     log.trace(f"Pipeline '{name}' returned result: {result}")
 
     return [TextContent(text=result, type="text")]
+
+
+async def notify_client(server: Server) -> None:
+    await server.request_context.session.send_tool_list_changed()
+
+
+async def create_mcp_server(name: str = "hayhooks-mcp-server") -> Server:
+    server: Server = Server(name)
+
+    @server.list_tools()
+    async def list_tools() -> List[Tool]:
+        try:
+            core_tools = await list_core_tools()
+            log.debug(f"Listing {len(core_tools)} core tools")
+
+            pipelines_tools = await list_pipelines_as_tools()
+            log.debug(f"Listing {len(pipelines_tools)} pipelines as tools")
+
+            return core_tools + pipelines_tools
+        except Exception as e:
+            log.error(f"Error listing tools: {e}")
+            return []
+
+    @server.call_tool()
+    async def call_tool(name: str, arguments: dict) -> List[TextContent | ImageContent | EmbeddedResource]:
+        try:
+            if name == CoreTools.DEPLOY_PIPELINE:
+                result = await asyncio.to_thread(
+                    deploy_pipeline_files,
+                    pipeline_name=arguments["name"],
+                    files=arguments["files"],
+                    app=None,
+                    save_files=arguments["save_files"],
+                    overwrite=arguments["overwrite"],
+                )
+                return [TextContent(type="text", text=f"Pipeline '{result['name']}' deployed successfully")]
+
+            elif name == CoreTools.GET_ALL_PIPELINE_STATUSES:
+                pipelines = registry.get_names()
+                pipelines_str = "\n".join(pipelines)
+                return [TextContent(type="text", text=f"Available pipelines:\n{pipelines_str}")]
+
+            elif name == CoreTools.GET_PIPELINE_STATUS:
+                pipeline_name = arguments["pipeline_name"]
+                is_deployed = pipeline_name in registry.get_names()
+                return [TextContent(type="text", text=f"Pipeline '{pipeline_name}' is deployed: {is_deployed}")]
+
+            elif name == CoreTools.UNDEPLOY_PIPELINE:
+                pipeline_name = arguments["pipeline_name"]
+                undeploy_pipeline(pipeline_name=pipeline_name)
+                return [TextContent(type="text", text=f"Pipeline '{pipeline_name}' undeployed")]
+
+            else:
+                log.debug(f"Attempting to run pipeline '{name}' as MCP Tool with arguments: {arguments}")
+
+                try:
+                    return await run_pipeline_as_tool(name, arguments)
+                except Exception as e_pipeline:
+                    log.error(f"Error calling pipeline as MCP Tool '{name}': {e_pipeline}")
+                    return [TextContent(type="text", text=f"Error calling tool '{name}': {e_pipeline}")]
+
+        except Exception as exc:
+            log.error(f"General unhandled error in call_tool for tool '{name}': {exc}")
+            return [
+                TextContent(type="text", text=f"An unexpected error occurred while processing tool '{name}': {exc}.")
+            ]
+
+        finally:
+            if name in [CoreTools.DEPLOY_PIPELINE, CoreTools.UNDEPLOY_PIPELINE]:
+                log.debug(f"Sending 'tools/list_changed' notification after deploy/undeploy")
+                await notify_client(server)
+
+    return server

--- a/tests/test_deploy_utils.py
+++ b/tests/test_deploy_utils.py
@@ -303,6 +303,26 @@ def test_deploy_pipeline_files_without_saving(test_settings, mocker):
     assert mock_app.setup.called
 
 
+def test_deploy_pipeline_files_without_adding_api_route(test_settings, mocker):
+    mock_app = mocker.Mock()
+
+    # We're saving the pipeline wrapper file in the test_files directory
+    test_file_path = Path("tests/test_files/files/no_chat/pipeline_wrapper.py")
+    files = {"pipeline_wrapper.py": test_file_path.read_text()}
+
+    # Run deploy_pipeline_files without adding the API route
+    result = deploy_pipeline_files(pipeline_name="test_pipeline_no_route", files=files, app=None, save_files=False)
+    assert result == {"name": "test_pipeline_no_route"}
+
+    # Verify the pipeline was deployed successfully
+    assert result == {"name": "test_pipeline_no_route"}
+    assert registry.get("test_pipeline_no_route") is not None
+
+    # Verify FastAPI routes were NOT set up
+    assert not mock_app.add_api_route.called
+    assert not mock_app.setup.called
+
+
 def test_deploy_pipeline_files_skip_mcp(mocker):
     mock_app = mocker.Mock()
     mock_app.routes = []

--- a/tests/test_it_mcp_server.py
+++ b/tests/test_it_mcp_server.py
@@ -5,9 +5,6 @@ from pathlib import Path
 from hayhooks.server.pipelines import registry
 from hayhooks.server.utils.deploy_utils import add_pipeline_to_registry
 from hayhooks.server.utils.mcp_utils import create_mcp_server, CoreTools
-from mcp.shared.memory import (
-    create_connected_server_and_client_session as client_session,
-)
 
 
 MCP_AVAILABLE = importlib.util.find_spec("mcp") is not None
@@ -23,6 +20,9 @@ pytestmark = [
 if MCP_AVAILABLE:
     from mcp.server import Server
     from mcp.types import TextContent
+    from mcp.shared.memory import (
+        create_connected_server_and_client_session as client_session,
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_it_mcp_server.py
+++ b/tests/test_it_mcp_server.py
@@ -1,0 +1,155 @@
+import pytest
+import importlib.util
+from unittest.mock import patch
+from pathlib import Path
+from hayhooks.server.pipelines import registry
+from hayhooks.server.utils.deploy_utils import add_pipeline_to_registry
+from hayhooks.server.utils.mcp_utils import create_mcp_server, CoreTools
+from mcp.shared.memory import (
+    create_connected_server_and_client_session as client_session,
+)
+
+
+MCP_AVAILABLE = importlib.util.find_spec("mcp") is not None
+
+# NOTE: Skip all tests in this file if MCP is not available
+pytestmark = [
+    pytest.mark.skipif(not MCP_AVAILABLE, reason="'mcp' package not installed"),
+    pytest.mark.mcp,
+    pytest.mark.integration,
+]
+
+# Conditional import for mcp types if needed, though skipif should guard tests
+if MCP_AVAILABLE:
+    from mcp.server import Server
+    from mcp.types import TextContent
+
+
+@pytest.fixture(autouse=True)
+def cleanup_test_pipelines():
+    registry.clear()
+    yield
+
+
+@pytest.fixture
+def deploy_chat_with_website_mcp_pipeline():
+    pipeline_name = "chat_with_website"
+    pipeline_wrapper_path = Path("tests/test_files/files/chat_with_website_mcp/pipeline_wrapper.py")
+    pipeline_yml_path = Path("tests/test_files/files/chat_with_website_mcp/chat_with_website.yml")
+    files = {
+        "pipeline_wrapper.py": pipeline_wrapper_path.read_text(),
+        "chat_with_website.yml": pipeline_yml_path.read_text(),
+    }
+    add_pipeline_to_registry(pipeline_name=pipeline_name, files=files)
+    return pipeline_name
+
+
+@pytest.fixture
+async def mcp_server_instance() -> "Server":
+    return await create_mcp_server()
+
+
+@pytest.mark.asyncio
+async def test_list_only_core_tools(mcp_server_instance):
+
+    async with client_session(mcp_server_instance) as client:
+        list_tools_result = await client.list_tools()
+
+        # With no pipelines deployed, the server should only have the core tools
+        assert len(list_tools_result.tools) == len(CoreTools)
+
+
+@pytest.mark.asyncio
+async def test_list_tools_with_one_pipeline_deployed(mcp_server_instance, deploy_chat_with_website_mcp_pipeline):
+    async with client_session(mcp_server_instance) as client:
+        list_tools_result = await client.list_tools()
+
+        # With one pipeline deployed, the server should have the core tools plus the pipeline tool
+        assert len(list_tools_result.tools) == len(CoreTools) + 1
+
+        # Find the tool for the deployed pipeline
+        pipeline_tool = next(
+            (tool for tool in list_tools_result.tools if tool.name == deploy_chat_with_website_mcp_pipeline), None
+        )
+        assert pipeline_tool is not None
+
+        # Check if the tool is the correct one
+        assert pipeline_tool.name == deploy_chat_with_website_mcp_pipeline
+        assert pipeline_tool.description == "Ask a question about one or more websites using a Haystack pipeline."
+        assert pipeline_tool.inputSchema == {
+            'properties': {
+                'urls': {
+                    'description': "Parameter 'urls'",
+                    'items': {'type': 'string'},
+                    'title': 'Urls',
+                    'type': 'array',
+                },
+                'question': {'description': "Parameter 'question'", 'title': 'Question', 'type': 'string'},
+            },
+            'required': ['urls', 'question'],
+            'title': 'chat_with_websiteRunRequest',
+            'type': 'object',
+        }
+
+
+@pytest.mark.asyncio
+async def test_call_pipeline_as_tool(mcp_server_instance, deploy_chat_with_website_mcp_pipeline):
+    async with client_session(mcp_server_instance) as client:
+        result = await client.call_tool(
+            deploy_chat_with_website_mcp_pipeline,
+            {"urls": ["https://www.google.com"], "question": "What is the capital of France?"},
+        )
+
+        # In the deployed pipeline, the response is mocked
+        assert result.content == [TextContent(type="text", text="This is a mock response from the pipeline")]
+
+
+@pytest.mark.asyncio
+async def test_call_pipeline_as_tool_with_invalid_arguments(mcp_server_instance, deploy_chat_with_website_mcp_pipeline):
+    async with client_session(mcp_server_instance) as client:
+        result = await client.call_tool(
+            deploy_chat_with_website_mcp_pipeline,
+            {"urls": ["https://www.google.com"]},
+        )
+
+        text_response = result.content[0].text
+        assert "missing 1 required positional argument: 'question'" in text_response
+
+
+@pytest.mark.asyncio
+async def test_call_pipeline_as_tool_with_invalid_pipeline_name(mcp_server_instance):
+    async with client_session(mcp_server_instance) as client:
+        result = await client.call_tool(
+            "invalid_pipeline_name",
+            {"urls": ["https://www.google.com"], "question": "What is the capital of France?"},
+        )
+
+        text_response = result.content[0].text
+        assert "Pipeline 'invalid_pipeline_name' not found" in text_response
+
+
+@pytest.mark.asyncio
+async def test_ensure_send_tool_list_changed_notification_after_deploy_or_undeploy(mcp_server_instance):
+    with patch("hayhooks.server.utils.mcp_utils.notify_client") as mock_notify_client:
+        async with client_session(mcp_server_instance) as client:
+
+            result = await client.call_tool(
+                CoreTools.DEPLOY_PIPELINE,
+                {
+                    "name": "chat_with_website",
+                    "files": {
+                        "pipeline_wrapper.py": Path(
+                            "tests/test_files/files/chat_with_website_mcp/pipeline_wrapper.py"
+                        ).read_text(),
+                        "chat_with_website.yml": Path(
+                            "tests/test_files/files/chat_with_website_mcp/chat_with_website.yml"
+                        ).read_text(),
+                    },
+                    "save_files": True,
+                    "overwrite": False,
+                },
+            )
+
+            assert result.content[0].text == "Pipeline 'chat_with_website' deployed successfully"
+
+        mock_notify_client.assert_called_once()

--- a/tests/test_it_mcp_server.py
+++ b/tests/test_it_mcp_server.py
@@ -45,8 +45,8 @@ def deploy_chat_with_website_mcp_pipeline():
 
 
 @pytest.fixture
-async def mcp_server_instance() -> "Server":
-    return await create_mcp_server()
+def mcp_server_instance() -> "Server":
+    return create_mcp_server()
 
 
 @pytest.mark.asyncio
@@ -153,3 +153,17 @@ async def test_ensure_send_tool_list_changed_notification_after_deploy_or_undepl
             assert result.content[0].text == "Pipeline 'chat_with_website' deployed successfully"
 
         mock_notify_client.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_call_tool_general_exception_handler(mcp_server_instance):
+    async with client_session(mcp_server_instance) as client:
+        result = await client.call_tool(
+            CoreTools.DEPLOY_PIPELINE,
+            {"name": "chat_with_website", "files": {}, "save_files": False, "overwrite": False},
+        )
+
+        assert len(result.content) == 1
+        assert isinstance(result.content[0], TextContent)
+        assert result.content[0].text.startswith("An unexpected error occurred while processing tool '")
+        assert "Failed to load pipeline module" in result.content[0].text

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -4,6 +4,9 @@ from hayhooks.server.pipelines import registry
 from pathlib import Path
 from hayhooks.server.utils.deploy_utils import add_pipeline_to_registry
 from hayhooks.server.utils.mcp_utils import list_pipelines_as_tools, run_pipeline_as_tool
+from hayhooks.server.utils.mcp_utils import list_core_tools, CoreTools, PIPELINE_NAME_SCHEMA
+from hayhooks.server.routers.deploy import PipelineFilesRequest
+from hayhooks.server.utils.deploy_utils import deploy_pipeline_files
 
 
 MCP_AVAILABLE = importlib.util.find_spec("mcp") is not None
@@ -13,6 +16,10 @@ pytestmark = [
     pytest.mark.skipif(not MCP_AVAILABLE, reason="'mcp' package not installed"),
     pytest.mark.mcp,
 ]
+
+# Conditional import for mcp.types.Tool if needed, though skipif should guard tests
+if MCP_AVAILABLE:
+    from mcp.types import Tool  # Required for type assertions in new tests
 
 
 @pytest.fixture(autouse=True)
@@ -49,7 +56,6 @@ async def test_list_pipelines_as_tools_no_pipelines():
 
 @pytest.mark.asyncio
 async def test_list_pipelines_as_tools(deploy_chat_with_website_mcp):
-    # List the pipelines as tools
     tools = await list_pipelines_as_tools()
 
     assert len(tools) == 1
@@ -105,3 +111,34 @@ async def test_run_pipeline_as_tool_returns_text_content(deploy_chat_with_websit
 async def test_skip_pipeline_from_mcp_listing(deploy_chat_with_website_mcp_skip):
     tools = await list_pipelines_as_tools()
     assert len(tools) == 0
+
+
+@pytest.mark.asyncio
+async def test_list_core_tools():
+    tools = await list_core_tools()
+    assert len(tools) == len(CoreTools)
+
+    core_tools_map = {tool.name: tool for tool in tools}
+
+    tool_get_all_statuses = core_tools_map.get(CoreTools.GET_ALL_PIPELINE_STATUSES.value)
+    assert tool_get_all_statuses is not None
+    assert tool_get_all_statuses.description == "Get the status of all pipelines and list available pipeline names."
+    assert tool_get_all_statuses.inputSchema == {"type": "object"}
+
+    tool_get_status = core_tools_map.get(CoreTools.GET_PIPELINE_STATUS.value)
+    assert tool_get_status is not None
+    assert tool_get_status.description == "Get status of a specific pipeline."
+    assert tool_get_status.inputSchema == PIPELINE_NAME_SCHEMA
+
+    tool_undeploy = core_tools_map.get(CoreTools.UNDEPLOY_PIPELINE.value)
+    assert tool_undeploy is not None
+    assert (
+        tool_undeploy.description
+        == "Undeploy a pipeline. Removes a pipeline from the registry, its API routes, and deletes its files."
+    )
+    assert tool_undeploy.inputSchema == PIPELINE_NAME_SCHEMA
+
+    tool_deploy = core_tools_map.get(CoreTools.DEPLOY_PIPELINE.value)
+    assert tool_deploy is not None
+    assert tool_deploy.description == "Deploy a pipeline from files (pipeline_wrapper.py and other files)."
+    assert tool_deploy.inputSchema == PipelineFilesRequest.model_json_schema()

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -6,7 +6,6 @@ from hayhooks.server.utils.deploy_utils import add_pipeline_to_registry
 from hayhooks.server.utils.mcp_utils import list_pipelines_as_tools, run_pipeline_as_tool
 from hayhooks.server.utils.mcp_utils import list_core_tools, CoreTools, PIPELINE_NAME_SCHEMA
 from hayhooks.server.routers.deploy import PipelineFilesRequest
-from hayhooks.server.utils.deploy_utils import deploy_pipeline_files
 
 
 MCP_AVAILABLE = importlib.util.find_spec("mcp") is not None
@@ -16,10 +15,6 @@ pytestmark = [
     pytest.mark.skipif(not MCP_AVAILABLE, reason="'mcp' package not installed"),
     pytest.mark.mcp,
 ]
-
-# Conditional import for mcp.types.Tool if needed, though skipif should guard tests
-if MCP_AVAILABLE:
-    from mcp.types import Tool  # Required for type assertions in new tests
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
This is to expose core Hayhooks APIs as MCP Tools. 

This will enable, from any MCP Client, the following actions:

- `get_all_pipeline_statuses` (Get the status of all pipelines and list available pipeline names.)
- `get_pipeline_status` Get status of a specific pipeline)
- `undeploy_pipeline` (Undeploy a pipeline. Removes a pipeline from the registry, its API routes, and deletes its files)
- `deploy_pipeline` (Deploy a pipeline from files (pipeline_wrapper.py and other files)

Of course, any deployed pipeline will be listed as a tool as well. 

- [x] We need also to look at [dynamic tool discovery](https://modelcontextprotocol.io/docs/concepts/tools#tool-discovery-and-updates) in order to let MCP Clients know that Tool list is updated after a pipeline deploy.