### PR TITLE
Fix `pipelines_dir` default path

### DIFF
--- a/src/hayhooks/settings.py
+++ b/src/hayhooks/settings.py
@@ -17,7 +17,7 @@ class AppSettings(BaseSettings):
 
     # Path to the directory containing the pipelines
     # Default to project root / pipelines
-    pipelines_dir: str = str(Path(__file__).parent.parent.parent / "pipelines")
+    pipelines_dir: str = str(Path.cwd() / "pipelines")
 
     # Additional Python path to be added to the Python path
     additional_python_path: str = ""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,7 +1,7 @@
 import sys
-import warnings
 import pytest
 import shutil
+from pathlib import Path
 from hayhooks.server.app import create_app
 from hayhooks.settings import AppSettings, check_cors_settings
 from unittest.mock import patch
@@ -19,6 +19,12 @@ def test_custom_pipelines_dir(temp_dir):
     custom_dir = temp_dir / "custom_pipelines"
     settings = AppSettings(pipelines_dir=str(custom_dir))
     assert settings.pipelines_dir == str(custom_dir)
+
+
+def test_default_pipelines_dir(monkeypatch):
+    monkeypatch.delenv("HAYHOOKS_PIPELINES_DIR", raising=False)
+    settings = AppSettings()
+    assert settings.pipelines_dir == str(Path.cwd() / "pipelines")
 
 
 def test_root_path():


### PR DESCRIPTION
This PR address a minor bug where we set an incorrect default value for `pipelines_dir`. 

Indeed, if you do `hayhooks run` from a fresh python venv, you'll find `pipelines` folder by default in the following (wrong) path:

```shell
{PROJECT_FOLDER}/.venv/lib/python3.12/pipelines
```

while it should be in `cwd()/pipelines`, so:

```shell
{PROJECT_FOLDER}/pipelines
```

Of course, if you were manually set `pipelines_dir` or `HAYHOOKS_PIPELINES_DIR`, everything works as expected.