### PR TITLE
Fix request model creation and MCP execution for pipeline wrappers with only `run_api_async` implemented

### DIFF
--- a/src/hayhooks/cli/mcp.py
+++ b/src/hayhooks/cli/mcp.py
@@ -1,4 +1,3 @@
-import asyncio
 import typer
 import uvicorn
 import sys

--- a/tests/test_files/files/async_question_answer/pipeline_wrapper.py
+++ b/tests/test_files/files/async_question_answer/pipeline_wrapper.py
@@ -21,32 +21,15 @@ class PipelineWrapper(BasePipelineWrapper):
     async def run_api_async(self, question: str) -> str:
         log.trace(f"Running pipeline with question: {question}")
 
-        result = await self.pipeline.run_async(
-            {
-                "prompt_builder": {
-                    "template": [
-                        ChatMessage.from_system(SYSTEM_MESSAGE),
-                        ChatMessage.from_user(question),
-                    ]
-                }
-            }
-        )
-        return result["llm"]["replies"][0].text
+        return "This is a mock response from the pipeline"
 
     async def run_chat_completion_async(self, model: str, messages: List[dict], body: dict) -> AsyncGenerator:
         log.trace(f"Running pipeline with model: {model}, messages: {messages}, body: {body}")
 
-        question = get_last_user_message(messages)
-        log.trace(f"Question: {question}")
+        mock_response = "This is a mock response from the pipeline"
 
-        return async_streaming_generator(
-            pipeline=self.pipeline,
-            pipeline_run_args={
-                "prompt_builder": {
-                    "template": [
-                        ChatMessage.from_system(SYSTEM_MESSAGE),
-                        ChatMessage.from_user(question),
-                    ]
-                },
-            },
-        )
+        async def mock_generator():
+            for word in mock_response.split():
+                yield word + " "
+
+        return mock_generator()


### PR DESCRIPTION
This fixes the following bugs:

1. Dynamic Pydantic request model creation for pipeline wrappers with only `run_api_async` implemented (so no `run_api`) wasn't working correctly (one was getting an empty request model for such wrappers since Hayhooks was wrongly looking only at `run_api` implementation)
2. The `run_pipeline_as_tool` for running pipeline wrappers as MCP tools wasn't considering correctly `run_api_async` (if implemented) and was also affected by 1).

