### PR TITLE
Add Streamable HTTP MCP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ Make sure [Node.js](https://nodejs.org/) is installed, as the `npx` command depe
 
 ### Using Hayhooks Core MCP Tools in IDEs like Cursor
 
-Since Hayhooks MCP Server provides by default a set of **Core MCP Tools**, you can use them in IDEs like [Cursor](https://www.cursor.com/) to interact with Hayhooks programmatically.
+Since Hayhooks MCP Server provides by default a set of **Core MCP Tools**, the MCP server will enable one to interact with Hayhooks in an agentic manner using IDEs like [Cursor](https://www.cursor.com/).
 
 The exposed tools are:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 
 [project.optional-dependencies]
 mcp = [
-  "mcp ; python_version >= '3.10'",
+  "mcp>=1.8.0 ; python_version >= '3.10'",
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 from hayhooks.server.app import create_app
 from hayhooks.settings import settings
 from hayhooks.server.pipelines.registry import registry
+from hayhooks.server.utils.mcp_utils import create_mcp_server, create_starlette_app
 
 
 def pytest_configure(config):
@@ -14,13 +15,23 @@ def pytest_configure(config):
 
 @pytest.fixture(scope="session", autouse=True)
 def test_settings():
-    settings.pipelines_dir = Path(__file__).parent / "pipelines"
+    settings.pipelines_dir = str(Path(__file__).parent / "pipelines")
     return settings
 
 
-@pytest.fixture
+@pytest.fixture(scope="session", autouse=True)
 def test_app():
     return create_app()
+
+
+@pytest.fixture
+def test_mcp_server():
+    return create_starlette_app(create_mcp_server(), debug=True, json_response=True)
+
+
+@pytest.fixture
+def test_mcp_client(test_mcp_server):
+    return TestClient(test_mcp_server)
 
 
 @pytest.fixture


### PR DESCRIPTION
This adds (stateless) [Streamable HTTP MCP transport](https://modelcontextprotocol.io/docs/concepts/transports#streamable-http) support.

The SSE transport (now deprecated) will still run together with Streamable HTTP one to maintain the compatibility with Claude Desktop, [which doesn't supports remote MCP Servers on free tier](https://support.anthropic.com/en/articles/11503834-building-custom-integrations-via-remote-mcp-servers) (only on paid ones).

On IDEs like Cursor, stateless Streamable HTTP will work smoothly.

So by default they will be both available at:

- <http://localhost:1417/sse> (SSE - deprecated)
- <http://localhost:1417/mcp> (HTTP)

Note that added Streamable HTTP transport doesn't yet support an Event Store for making client sessions resumable.

I've added two lower-level tests to ensure endpoints for both transports exists and respond correctly (especially Streamable HTTP one).