### PR TITLE
Force `media_type` on `Form` to make Swagger use `multipart/form-data` content-type

### DIFF
--- a/src/hayhooks/server/utils/deploy_utils.py
+++ b/src/hayhooks/server/utils/deploy_utils.py
@@ -264,7 +264,7 @@ def create_run_endpoint_handler(
     """
 
     @handle_pipeline_exceptions()
-    async def run_endpoint_with_files(run_req: request_model = Form(...)) -> response_model:  # type: ignore
+    async def run_endpoint_with_files(run_req: request_model = Form(..., media_type="multipart/form-data")) -> response_model:  # type: ignore
         if pipeline_wrapper._is_run_api_async_implemented:
             result = await pipeline_wrapper.run_api_async(**run_req.model_dump())  # type: ignore
         else:


### PR DESCRIPTION
Fixes https://github.com/deepset-ai/hayhooks/issues/139.

With this, we're simply forcing `media_type` of `Form` to `multipart/form-data` (before it was `application/x-www-form-urlencoded`). Nothing changes, but on Swagger you finally can test this out without issues.

<img width="1453" height="1144" alt="Screenshot 2025-08-04 at 21 18 26" src="https://github.com/user-attachments/assets/9415ea5c-d99a-480f-a07a-47c7555bcb89" />
