### PR TITLE
Add a /status endpoint to MCP server

### DIFF
--- a/src/hayhooks/server/utils/mcp_utils.py
+++ b/src/hayhooks/server/utils/mcp_utils.py
@@ -20,6 +20,7 @@ from hayhooks.server.routers.deploy import PipelineFilesRequest
 from fastapi.concurrency import run_in_threadpool
 from contextlib import asynccontextmanager
 from starlette.applications import Starlette
+from starlette.responses import JSONResponse
 from starlette.routing import Mount, Route
 from starlette.types import Receive, Scope, Send
 from typing import AsyncIterator
@@ -267,10 +268,14 @@ def create_starlette_app(server: "Server", *, debug: bool = False, json_response
         async with sse.connect_sse(request.scope, request.receive, request._send) as streams:
             await server.run(streams[0], streams[1], server.create_initialization_options())
 
+    async def handle_status(request):
+        return JSONResponse({"status": "ok"})
+
     return Starlette(
         debug=debug,
         routes=[
             Route("/sse", endpoint=handle_sse),
+            Route("/status", endpoint=handle_status),
             Mount("/messages/", app=sse.handle_post_message),
             Mount("/mcp", app=handle_streamable_http),
         ],

--- a/tests/test_it_mcp_server.py
+++ b/tests/test_it_mcp_server.py
@@ -248,3 +248,11 @@ def test_sse_transport(test_mcp_client):
         # This verifies the endpoint exists and can handle requests
         messages_response = client.get("/messages/")
         assert messages_response.status_code != 404
+
+
+def test_mcp_server_status_endpoint(test_mcp_client):
+    with test_mcp_client as client:
+        response = client.get("/status")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
Fixes https://github.com/deepset-ai/hayhooks/issues/143.

This pull request introduces a new `/status` endpoint to the MCP server, which provides a simple health check response.