### PR TITLE
Raise a `PipelineWrapperError` if `run_api` or `run_api_async` have no return type

### DIFF
--- a/src/hayhooks/server/utils/deploy_utils.py
+++ b/src/hayhooks/server/utils/deploy_utils.py
@@ -216,6 +216,10 @@ def create_response_model_from_callable(func: Callable, model_name: str, docstri
     """
 
     return_type = inspect.signature(func).return_annotation
+
+    if return_type is inspect.Signature.empty:
+        raise PipelineWrapperError(f"Pipeline wrapper is missing a return type for '{func.__name__}' method")
+
     return_description = docstring.returns.description if docstring.returns else None
 
     return create_model(f'{model_name}Response', result=(return_type, Field(..., description=return_description)))

--- a/tests/test_deploy_utils.py
+++ b/tests/test_deploy_utils.py
@@ -405,3 +405,13 @@ def test_add_pipeline_to_registry_with_async_run_api():
     schema = request_model.model_json_schema()
     assert "question" in schema["properties"]
     assert schema["properties"]["question"]["type"] == "string"
+
+
+def test_deploy_pipeline_files_without_return_type(test_settings, mocker):
+    mock_app = mocker.Mock()
+
+    test_file_path = Path("tests/test_files/files/no_return_type/pipeline_wrapper.py")
+    files = {"pipeline_wrapper.py": test_file_path.read_text()}
+
+    with pytest.raises(PipelineWrapperError, match="Pipeline wrapper is missing a return type for 'run_api' method"):
+        deploy_pipeline_files(app=mock_app, pipeline_name="test_pipeline_no_return_type", files=files, save_files=False)

--- a/tests/test_files/files/no_return_type/pipeline_wrapper.py
+++ b/tests/test_files/files/no_return_type/pipeline_wrapper.py
@@ -1,0 +1,10 @@
+from haystack import Pipeline
+from hayhooks import BasePipelineWrapper
+
+
+class PipelineWrapper(BasePipelineWrapper):
+    def setup(self):
+        self.pipeline = Pipeline()
+
+    def run_api(self, test_param: str):
+        return f"Dummy result with {test_param}"


### PR DESCRIPTION
When you have something like:

```python
from haystack import Pipeline
from hayhooks import BasePipelineWrapper


class PipelineWrapper(BasePipelineWrapper):
    def setup(self):
        self.pipeline = Pipeline()

    def run_api(self, test_param: str):
        return f"Dummy result with {test_param}"
```

So no defined return type for `run_api`. Currently this is unhandled in Hayhooks (deploy fails since it cannot dynamically create a response model).

The idea is instead to return an error with this message: `Pipeline wrapper is missing a return type for 'run_api' method`.

Note that in FastAPI it's not mandatory to have a Pydantic model for response, but generally it's highly recommended and will improve DX and docs.