### PR TITLE
chore: set required_variables in Prompt Builders to reduce noise in logs

### DIFF
--- a/examples/pipeline_wrappers/async_question_answer/question_answer.yml
+++ b/examples/pipeline_wrappers/async_question_answer/question_answer.yml
@@ -19,7 +19,7 @@ components:
     type: haystack.components.generators.chat.openai.OpenAIChatGenerator
   prompt_builder:
     init_parameters:
-      required_variables: null
+      required_variables: "*"
       template: null
       variables: null
     type: haystack.components.builders.chat_prompt_builder.ChatPromptBuilder

--- a/examples/pipeline_wrappers/chat_with_website/chat_with_website.yml
+++ b/examples/pipeline_wrappers/chat_with_website/chat_with_website.yml
@@ -37,6 +37,7 @@ components:
         Answer the given question: {{query}}
         Answer:
         "
+      required_variables: "*"
     type: haystack.components.builders.prompt_builder.PromptBuilder
 
 connections:

--- a/examples/pipeline_wrappers/chat_with_website_mcp/chat_with_website.yml
+++ b/examples/pipeline_wrappers/chat_with_website_mcp/chat_with_website.yml
@@ -37,6 +37,7 @@ components:
         Answer the given question: {{query}}
         Answer:
         "
+      required_variables: "*"
     type: haystack.components.builders.prompt_builder.PromptBuilder
 
 connections:

--- a/examples/pipeline_wrappers/chat_with_website_streaming/chat_with_website.yml
+++ b/examples/pipeline_wrappers/chat_with_website_streaming/chat_with_website.yml
@@ -37,6 +37,7 @@ components:
         Answer the given question: {{query}}
         Answer:
         "
+      required_variables: "*"
     type: haystack.components.builders.prompt_builder.PromptBuilder
 
 connections:

--- a/examples/rag_indexing_query/query_pipeline/pipeline_wrapper.py
+++ b/examples/rag_indexing_query/query_pipeline/pipeline_wrapper.py
@@ -36,7 +36,7 @@ class PipelineWrapper(BasePipelineWrapper):
             SentenceTransformersTextEmbedder(model="sentence-transformers/all-MiniLM-L6-v2"),
         )
         pipe.add_component("retriever", ElasticsearchEmbeddingRetriever(document_store=document_store))
-        pipe.add_component("chat_prompt_builder", ChatPromptBuilder(template=template))
+        pipe.add_component("chat_prompt_builder", ChatPromptBuilder(template=template, required_variables="*"))
         pipe.add_component(
             "llm",
             HuggingFaceAPIChatGenerator(

--- a/tests/test_files/files/async_chat_with_website/chat_with_website.yml
+++ b/tests/test_files/files/async_chat_with_website/chat_with_website.yml
@@ -37,6 +37,7 @@ components:
         Answer the given question: {{query}}
         Answer:
         "
+      required_variables: "*"
     type: haystack.components.builders.prompt_builder.PromptBuilder
 
 connections:

--- a/tests/test_files/files/async_chat_with_website_streaming/chat_with_website.yml
+++ b/tests/test_files/files/async_chat_with_website_streaming/chat_with_website.yml
@@ -37,6 +37,7 @@ components:
         Answer the given question: {{query}}
         Answer:
         "
+      required_variables: "*"
     type: haystack.components.builders.prompt_builder.PromptBuilder
 
 connections:

--- a/tests/test_files/files/async_question_answer/question_answer.yml
+++ b/tests/test_files/files/async_question_answer/question_answer.yml
@@ -19,7 +19,7 @@ components:
     type: haystack.components.generators.chat.openai.OpenAIChatGenerator
   prompt_builder:
     init_parameters:
-      required_variables: null
+      required_variables: "*"
       template: null
       variables: null
     type: haystack.components.builders.chat_prompt_builder.ChatPromptBuilder

--- a/tests/test_files/files/chat_with_website/chat_with_website.yml
+++ b/tests/test_files/files/chat_with_website/chat_with_website.yml
@@ -37,6 +37,7 @@ components:
         Answer the given question: {{query}}
         Answer:
         "
+      required_variables: "*"
     type: haystack.components.builders.prompt_builder.PromptBuilder
 
 connections:

--- a/tests/test_files/files/chat_with_website_mcp/chat_with_website.yml
+++ b/tests/test_files/files/chat_with_website_mcp/chat_with_website.yml
@@ -37,6 +37,7 @@ components:
         Answer the given question: {{query}}
         Answer:
         "
+      required_variables: "*"
     type: haystack.components.builders.prompt_builder.PromptBuilder
 
 connections:

--- a/tests/test_files/files/chat_with_website_streaming/chat_with_website.yml
+++ b/tests/test_files/files/chat_with_website_streaming/chat_with_website.yml
@@ -37,6 +37,7 @@ components:
         Answer the given question: {{query}}
         Answer:
         "
+      required_variables: "*"
     type: haystack.components.builders.prompt_builder.PromptBuilder
 
 connections:

--- a/tests/test_files/files/no_wrapper/chat_with_website.yml
+++ b/tests/test_files/files/no_wrapper/chat_with_website.yml
@@ -37,6 +37,7 @@ components:
         Answer the given question: {{query}}
         Answer:
         "
+      required_variables: "*"
     type: haystack.components.builders.prompt_builder.PromptBuilder
 
 connections:

--- a/tests/test_files/mixed/basic_rag_pipeline.yml
+++ b/tests/test_files/mixed/basic_rag_pipeline.yml
@@ -15,7 +15,7 @@ components:
     type: haystack.components.generators.openai.OpenAIGenerator
   prompt_builder:
     init_parameters:
-      required_variables: null
+      required_variables: "*"
       template: "\nGiven the following information, answer the question.\n\nContext:\n\
         {% for document in documents %}\n    {{ document.content }}\n{% endfor %}\n\
         \nQuestion: {{question}}\nAnswer:\n"

--- a/tests/test_files/mixed/chat_with_website/chat_with_website.yml
+++ b/tests/test_files/mixed/chat_with_website/chat_with_website.yml
@@ -37,6 +37,7 @@ components:
         Answer the given question: {{query}}
         Answer:
         "
+      required_variables: "*"
     type: haystack.components.builders.prompt_builder.PromptBuilder
 
 connections:

--- a/tests/test_files/yaml/broken_rag_pipeline.yml
+++ b/tests/test_files/yaml/broken_rag_pipeline.yml
@@ -15,7 +15,7 @@ components:
     type: haystack.components.generators.openai.OpenAIGenerator
   prompt_builder:
     init_parameters:
-      required_variables: null
+      required_variables: "*"
       template: "{{ question }}"
       variables: null
     type: haystack.components.builders.prompt_builder.PromptBuilder

--- a/tests/test_files/yaml/working_pipelines/basic_rag_pipeline.yml
+++ b/tests/test_files/yaml/working_pipelines/basic_rag_pipeline.yml
@@ -15,7 +15,7 @@ components:
     type: haystack.components.generators.openai.OpenAIGenerator
   prompt_builder:
     init_parameters:
-      required_variables: null
+      required_variables: "*"
       template: "\nGiven the following information, answer the question.\n\nContext:\n\
         {% for document in documents %}\n    {{ document.content }}\n{% endfor %}\n\
         \nQuestion: {{question}}\nAnswer:\n"

--- a/tests/test_files/yaml/working_pipelines/chat_with_website.yml
+++ b/tests/test_files/yaml/working_pipelines/chat_with_website.yml
@@ -37,6 +37,7 @@ components:
         Answer the given question: {{query}}
         Answer:
         "
+      required_variables: "*"
     type: haystack.components.builders.prompt_builder.PromptBuilder
 
 connections:

--- a/tests/test_files/yaml/working_pipelines/pipeline_qdrant.yml
+++ b/tests/test_files/yaml/working_pipelines/pipeline_qdrant.yml
@@ -85,7 +85,7 @@ components:
     type: haystack.components.generators.openai.OpenAIGenerator
   query_rephrase_prompt_builder:
     init_parameters:
-      required_variables: null
+      required_variables: "*"
       template: "\nRewrite the question for semantic search while keeping its meaning\
         \ and key terms intact.\nIf the conversation history is empty, DO NOT change\
         \ the query.\nDo not translate the question.\nUse conversation history only\

--- a/tests/test_it_pipeline_utils.py
+++ b/tests/test_it_pipeline_utils.py
@@ -21,7 +21,7 @@ QUESTION = "Is Haystack a framework for developing AI applications? Answer Yes o
 @pytest.fixture
 def sync_pipeline_with_sync_streaming_callback_support():
     pipeline = Pipeline()
-    pipeline.add_component("prompt_builder", ChatPromptBuilder())
+    pipeline.add_component("prompt_builder", ChatPromptBuilder(required_variables="*"))
     pipeline.add_component(
         "llm", OpenAIChatGenerator(api_key=Secret.from_env_var("OPENAI_API_KEY"), model="gpt-4o-mini")
     )
@@ -35,7 +35,7 @@ def async_pipeline_with_async_streaming_callback_support():
     NOTE: `OpenAIChatGenerator` supports both _async_ and _sync_ `streaming_callback`.
     """
     pipeline = AsyncPipeline()
-    pipeline.add_component("prompt_builder", ChatPromptBuilder())
+    pipeline.add_component("prompt_builder", ChatPromptBuilder(required_variables="*"))
     pipeline.add_component(
         "llm", OpenAIChatGenerator(api_key=Secret.from_env_var("OPENAI_API_KEY"), model="gpt-4o-mini")
     )
@@ -46,7 +46,7 @@ def async_pipeline_with_async_streaming_callback_support():
 @pytest.fixture
 def async_pipeline_without_async_streaming_callback_support():
     pipeline = AsyncPipeline()
-    pipeline.add_component("prompt_builder", PromptBuilder(template=QUESTION))
+    pipeline.add_component("prompt_builder", PromptBuilder(template=QUESTION, required_variables="*"))
     pipeline.add_component("llm", OpenAIGenerator(api_key=Secret.from_env_var("OPENAI_API_KEY"), model="gpt-4o-mini"))
     pipeline.connect("prompt_builder.prompt", "llm.prompt")
     return pipeline


### PR DESCRIPTION
In #155, I set `log_cli = true` in pytest options. https://docs.pytest.org/en/stable/how-to/logging.html#live-logs

I immediately started to see a lot of warnings coming from Prompt Builder and Chat Prompt Builder.
In this small PR, I am setting `required_variables=True` in Prompt Builder and Chat Prompt Builder to avoid all of them.

In any case, I think it can be helpful to have log records in the CLI.