### PR TITLE
fix: add utf8 support for hayhooks pipeline

### DIFF
--- a/src/hayhooks/server/utils/deploy_utils.py
+++ b/src/hayhooks/server/utils/deploy_utils.py
@@ -107,7 +107,7 @@ def save_pipeline_files(pipeline_name: str, files: dict[str, str], pipelines_dir
             file_path.parent.mkdir(parents=True, exist_ok=True)
 
             # Save file content
-            file_path.write_text(content)
+            file_path.write_text(content, encoding="utf8")
             saved_files[filename] = str(file_path)
 
         return saved_files


### PR DESCRIPTION
for pipeline_wrapper.py with unicode  characters

<img width="1116" height="127" alt="image" src="https://github.com/user-attachments/assets/857717d4-cc22-4628-a452-b175e2866040" />

if any code with unicode characters, then deploy-files will be failed