### PR TITLE
fix docs to use `deepset/hayhooks:main` Docker image

### DIFF
--- a/docs/deployment/deployment_guidelines.md
+++ b/docs/deployment/deployment_guidelines.md
@@ -173,7 +173,7 @@ docker run -d \
   -e HAYHOOKS_HOST=0.0.0.0 \
   -e HAYHOOKS_PIPELINES_DIR=/app/pipelines \
   -v "$PWD/pipelines:/app/pipelines:ro" \
-  deepset/hayhooks:latest
+  deepset/hayhooks:main
 ```
 
 ### Docker Compose
@@ -182,7 +182,7 @@ docker run -d \
 version: '3.8'
 services:
   hayhooks:
-    image: deepset/hayhooks:latest
+    image: deepset/hayhooks:main
     ports:
       - "1416:1416"
     environment:
@@ -203,7 +203,7 @@ Add health checks to monitor container health:
 ```yaml
 services:
   hayhooks:
-    image: deepset/hayhooks:latest
+    image: deepset/hayhooks:main
     ports:
       - "1416:1416"
     environment:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -104,12 +104,14 @@ pip install -e .
 ### Using Docker Hub
 
 ```bash
-# Pull the latest image
-docker pull deepset/hayhooks:latest
+# Pull the image corresponding to Hayhooks main branch
+docker pull deepset/hayhooks:main
 
 # Run Hayhooks
-docker run -p 1416:1416 deepset/hayhooks:latest
+docker run -p 1416:1416 deepset/hayhooks:main
 ```
+
+You can inspect all available images on [Docker Hub](https://hub.docker.com/r/deepset/hayhooks/tags).
 
 ### Building from Source
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -116,7 +116,7 @@ docker run -d \
   -e HAYHOOKS_PIPELINES_DIR=/app/pipelines \
   -v "$PWD/pipelines:/app/pipelines:ro" \
   -p 1416:1416 \
-  deepset/hayhooks:latest
+  deepset/hayhooks:main
 ```
 
 !!! warning "Pipeline Directory Required"


### PR DESCRIPTION
In the docs, we were incorrectly pointing to `deepset/hayhooks:latest`, that does not exist.