### PR TITLE
docs: add warning about OpenAIChatGenerator when using Open WebUI events

### DIFF
--- a/docs/features/openai-compatibility.md
+++ b/docs/features/openai-compatibility.md
@@ -194,6 +194,9 @@ This enables powerful use cases:
 - **Testing**: Test your pipelines using Haystack's testing tools
 - **Hybrid Deployments**: Mix local and remote pipeline execution
 
+!!! warning "Limitations"
+    If you customize your Pipeline wrapper to emit [Open WebUI Events](../features/openwebui-integration.md#open-webui-events), it may break out-of-the-box compatibility with Haystack's `OpenAIChatGenerator`.
+
 ## Examples
 
 ### Sync Chat Pipeline (Non-Streaming)

--- a/docs/features/openwebui-integration.md
+++ b/docs/features/openwebui-integration.md
@@ -100,6 +100,10 @@ Hayhooks supports sending events to Open WebUI for enhanced user experience:
 - **notification**: Show toast notifications (info, success, warning, error)
 - **source**: Add references, citations, or code execution results
 
+!!! warning "Limitations"
+    Customizing your Pipeline wrapper to emit Open WebUI Events may break out-of-the-box compatibility with [Haystack's `OpenAIChatGenerator`](../features/openai-compatibility.md#using-hayhooks-with-haystacks-openaichatgenerator).
+    Your pipeline will still function normally, but it may not be directly consumable through `OpenAIChatGenerator`.
+
 ### Event Implementation
 
 ```python


### PR DESCRIPTION
https://github.com/deepset-ai/haystack-enterprise/pull/26#issuecomment-3382099138

We want to inform users that emitting Open WebUI events may break compatibility with consuming the Pipeline via  `OpenAIChatGenerator`