### PR TITLE
chore: Remove email address from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ requires-python = ">=3.9,<3.13"
 license = "Apache-2.0"
 keywords = []
 authors = [
-  { name = "Massimiliano Pippi", email = "mpippi@gmail.com" },
   { name = "deepset.ai", email = "malte.pietsch@deepset.ai" }
 ]
 classifiers = [


### PR DESCRIPTION
As suggested by @sjrl , similar to haystack and haystack-experimental repositories, we should only list one deepset email address as contact info.

https://github.com/deepset-ai/haystack/blob/main/pyproject.toml#L12
https://github.com/deepset-ai/haystack-experimental/blob/main/pyproject.toml#L12