### PR TITLE
Update haystack-ai dep version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "haystack-ai>=2.11.0",
+  "haystack-ai!=2.18.0",
   "fastapi[standard]",
   "typer",
   "uvicorn",


### PR DESCRIPTION
We're updating the `haystack-ai` dep to:

```text
haystack-ai!=2.18.0
```

Note that version `2.18.0` had [this issue](https://github.com/deepset-ai/haystack/issues/9825) which was breaking the streaming on Open WebUI.