### PR TITLE
Add `llms-txt` plugin for automatic `llms.txt` generation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,50 @@ theme:
 plugins:
   - search
   - tags
+  - llmstxt:
+      markdown_description: >
+        Hayhooks turns Haystack Pipelines and Agents into production-ready REST
+        APIs, bundling deployment, observability, lifecycle tooling, and native
+        Model Context Protocol (MCP) endpoints for MCP-aware clients such as
+        Cursor or Claude Desktop.
+      full_output: llms-full.txt
+      sections:
+        Overview:
+          - index.md: Project overview and key capabilities.
+        Getting Started:
+          - getting-started/quick-start.md: Launch Hayhooks locally with the default settings.
+          - getting-started/quick-start-docker.md: Run Hayhooks with Docker Compose for a managed setup.
+          - getting-started/installation.md: Install Hayhooks and its dependencies.
+          - getting-started/configuration.md: Configure Hayhooks for your environment.
+        Core Concepts:
+          - concepts/pipeline-wrapper.md: Understand the PipelineWrapper abstraction.
+          - concepts/pipeline-deployment.md: Learn how to deploy Haystack Pipelines with Hayhooks.
+          - concepts/agent-deployment.md: Learn how to deploy Haystack Agents with Hayhooks.
+          - concepts/yaml-pipeline-deployment.md: Define and deploy Haystack Pipelines from YAML.
+        Features:
+          - features/openai-compatibility.md: Use Hayhooks with OpenAI-compatible clients.
+          - features/mcp-support.md: Using Hayhooks as an MCP Server for Haystack Pipelines and Agents.
+          - features/openwebui-integration.md: Connect Hayhooks to Open WebUI.
+          - features/file-upload-support.md: Handle file uploads inside pipeline runs.
+          - features/cli-commands.md: Discover the Hayhooks command-line tooling.
+        Advanced Usage:
+          - advanced/running-pipelines.md: Execute Haystack Pipelines and manage runs programmatically.
+          - advanced/advanced-configuration.md: Fine-tune advanced configuration settings.
+          - advanced/code-sharing.md: Share Python code securely across deployments.
+        Deployment:
+          - deployment/deployment_guidelines.md: Follow best practices for production deployments.
+        Examples:
+          - examples/overview.md: Explore the examples shipped with Hayhooks.
+          - examples/chat-with-website.md: Build a Haystack website-aware chat assistant.
+          - examples/rag-system.md: Assemble a Haystack RAG system with Hayhooks.
+          - examples/async-operations.md: Run asynchronous operations with Haystack Pipelines and Agents.
+          - examples/openwebui-events.md: Handle Open WebUI event integrations.
+        Reference:
+          - reference/api-reference.md: REST API reference for Haystack Pipelines and Agents endpoints.
+          - reference/environment-variables.md: Environment variables and their defaults.
+          - reference/logging.md: Logging configuration and observability guidance.
+        About:
+          - about/license.md: Project licensing details.
 
 markdown_extensions:
   - admonition
@@ -128,7 +172,7 @@ extra:
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/deepset_ai
 
-extra_css: 
+extra_css:
   - stylesheets/extra.css
 
 extra_javascript: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dependencies = [
   "mkdocs-mermaid2-plugin",
   "mkdocs-minify-plugin",
   "mkdocs-git-revision-date-localized-plugin",
+  "mkdocs-llmstxt",
 ]
 
 [tool.hatch.envs.docs.scripts]


### PR DESCRIPTION
This will automatically generate:

- `{docs-website}/llms-full.txt`
- `{docs-website}/llms.txt`

according to `mkdocs` configuration. Will be useful to integrate Hayhooks docs with e.g. [@docs](https://cursor.com/docs/context/symbols#docs) feature of Cursor or any other tool which can programmatically use docs.