### PR TITLE
Using ubuntu-slim on some workflows

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   add-to-project:
     name: Add new issues to project for triage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/add-to-project@v1.0.1
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release-on-pypi:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         run: hatch run test:all-cov
 
   linting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
For some workflows which are not CPU-intensive or not in need of resources, I am updating the `runs-on` value to `ubuntu-slim`, since it's a lot cheaper (see [here](https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/) for more details).

Should be reasonable to use it for any lightweight workflow.