### PR TITLE
Add tracing support to Hayhooks 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ With Hayhooks, you can:
 - 💬 **Integrate your Haystack pipelines and agents with [Open WebUI](https://openwebui.com)** as OpenAI-compatible chat completion backends with streaming support.
 - 🖥️ **Embed a [Chainlit](https://chainlit.io/) chat UI** directly in Hayhooks with `pip install "hayhooks[chainlit]"` and `hayhooks run --with-chainlit` -- zero-configuration frontend with streaming, pipeline selection, and custom UI widgets.
 - 🕹️ **Control Hayhooks core API endpoints through chat** - deploy, undeploy, list, or run Haystack pipelines and agents by chatting with [Claude Desktop](https://claude.ai/download), [Cursor](https://cursor.com), or any other MCP client.
+- 📈 **Trace Hayhooks lifecycle actions with OpenTelemetry** (`pip install "hayhooks[tracing]"`) for deploy/run/undeploy visibility across REST and MCP.
 
 [![PyPI - Version](https://img.shields.io/pypi/v/hayhooks.svg)](https://pypi.org/project/hayhooks)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/hayhooks.svg)](https://pypi.org/project/hayhooks)
@@ -143,6 +144,7 @@ Or chat with it in the [embedded Chainlit UI](docs/features/chainlit-integration
 - CLI for easy pipeline management
 - Flexible configuration options
 - Comprehensive logging and debugging support
+- OpenTelemetry-ready tracing hooks built on Haystack tracing APIs
 - Custom route and middleware support
 
 ### 📁 File Upload Support

--- a/docs/features/mcp-support.md
+++ b/docs/features/mcp-support.md
@@ -237,6 +237,21 @@ Configure Claude Desktop to connect to Hayhooks MCP Server:
 3. Configure your IDE to connect to the MCP server
 4. Deploy and manage pipelines through your IDE using natural language
 
+## Tracing MCP Operations
+
+To emit OpenTelemetry traces for MCP requests and tool calls, install tracing extras:
+
+```bash
+pip install "hayhooks[tracing]"
+```
+
+With tracing enabled, Hayhooks emits:
+
+- Request-level spans for MCP transport endpoints (`/mcp`, `/sse`) via Starlette instrumentation
+- Domain spans for MCP actions such as `list_tools`, `call_tool`, pipeline deploy/undeploy, and pipeline-as-tool execution
+
+This allows dashboards to distinguish REST-triggered vs MCP-triggered pipeline operations.
+
 ## Tool Development
 
 ### Custom Tool Descriptions

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -30,6 +30,16 @@ This guide covers how to install Hayhooks and its dependencies.
     !!! warning "Python 3.10+ Required"
         You'll need to run at least Python 3.10+ to use the MCP Server.
 
+=== "With Tracing Support"
+
+    ```bash
+    pip install "hayhooks[tracing]"
+    ```
+
+    Includes OpenTelemetry SDK, OTLP exporter support, and FastAPI/Starlette instrumentors so Hayhooks can emit
+    request-level traces alongside Haystack span instrumentation. Hayhooks also auto-bootstraps OTLP tracing
+    when an OTLP endpoint is configured via `OTEL_EXPORTER_OTLP_ENDPOINT` or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.
+
 === "From Source"
 
     ```bash

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -231,6 +231,8 @@ export HAYHOOKS_INTERCEPTED_LOGGERS='["uvicorn", "uvicorn.error", "uvicorn.acces
 
 Hayhooks tracing relies on Haystack tracing APIs and standard OpenTelemetry configuration.
 
+For setup walkthroughs and backend examples (SigNoz, Jaeger), see [Tracing](tracing.md).
+
 Install tracing extras first:
 
 ```bash
@@ -286,51 +288,6 @@ When `OTEL_EXPORTER_OTLP_ENDPOINT` (or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`) is 
 an automatic OpenTelemetry bootstrap at startup using the protocol from `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`
 (falling back to `OTEL_EXPORTER_OTLP_PROTOCOL`)
 (`http/protobuf` default, or `grpc`).
-
-### Recommended OSS stack (local and small deployments)
-
-#### Option A: SigNoz (recommended UI)
-
-SigNoz provides a richer trace-exploration UI while staying fully open source.
-
-Start SigNoz locally:
-
-```bash
-git clone -b main https://github.com/SigNoz/signoz.git
-cd signoz/deploy/docker
-docker compose up -d --remove-orphans
-```
-
-Then point Hayhooks/OpenTelemetry to the SigNoz collector:
-
-```bash
-export OTEL_SERVICE_NAME=hayhooks
-export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
-export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-export OTEL_TRACES_SAMPLER=parentbased_traceidratio
-export OTEL_TRACES_SAMPLER_ARG=1.0
-export HAYHOOKS_TRACING_EXCLUDED_SPANS='["send", "receive"]'
-```
-
-Open SigNoz at `http://localhost:8080`, then go to **Traces** and filter by service `hayhooks`.
-
-#### Option B: Jaeger (minimal setup)
-
-If you want a lighter single-container setup:
-
-```bash
-docker run --rm -d \
-  --name jaeger \
-  -e COLLECTOR_OTLP_ENABLED=true \
-  -p 16686:16686 \
-  -p 4318:4318 \
-  jaegertracing/all-in-one:latest
-```
-
-Use the same `OTEL_*` variables shown above and open Jaeger at `http://localhost:16686`.
-
-For advanced setups, you can still initialize your own OpenTelemetry SDK tracer provider before importing
-Hayhooks/Haystack and Hayhooks will use that configured provider.
 
 ## Usage Examples
 
@@ -397,4 +354,5 @@ HAYHOOKS_LOG_FORMAT=default
 ## Next Steps
 
 - [Configuration](../getting-started/configuration.md)
+- [Tracing](tracing.md)
 - [Logging](logging.md)

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,6 +1,6 @@
 # Environment Variables
 
-Hayhooks can be configured via environment variables (loaded with prefix `HAYHOOKS_` or `LOG`). This page lists the canonical variables supported by the codebase.
+Hayhooks can be configured via environment variables. Most app settings use the `HAYHOOKS_` prefix (plus the legacy `LOG` alias for log level), while tracing uses standard OpenTelemetry `OTEL_*` variables. This page lists the canonical variables supported by the codebase.
 
 ## Server
 
@@ -226,6 +226,111 @@ export HAYHOOKS_LOG_FORMAT=verbose
 # Also intercept haystack logs
 export HAYHOOKS_INTERCEPTED_LOGGERS='["uvicorn", "uvicorn.error", "uvicorn.access", "fastapi", "haystack"]'
 ```
+
+## OpenTelemetry (Tracing)
+
+Hayhooks tracing relies on Haystack tracing APIs and standard OpenTelemetry configuration.
+
+Install tracing extras first:
+
+```bash
+pip install "hayhooks[tracing]"
+```
+
+Then configure your exporter/provider using OpenTelemetry env vars (examples):
+
+### OTEL_SERVICE_NAME
+
+- Example: `hayhooks`
+- Description: Service name shown in your tracing backend
+
+### OTEL_EXPORTER_OTLP_ENDPOINT
+
+- Example: `http://localhost:4318`
+- Description: OTLP collector endpoint
+
+!!! tip "Using OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+    If you set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` directly for HTTP transport, use the full traces path
+    (for example `http://localhost:4318/v1/traces`).
+
+### OTEL_EXPORTER_OTLP_TRACES_PROTOCOL / OTEL_EXPORTER_OTLP_PROTOCOL
+
+- Example: `http/protobuf`
+- Description: OTLP transport protocol (`http/protobuf` or `grpc`). If both are set, `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` takes precedence for trace export.
+
+### OTEL_TRACES_SAMPLER
+
+- Example: `parentbased_traceidratio`
+- Description: Sampling strategy
+
+### OTEL_TRACES_SAMPLER_ARG
+
+- Example: `1.0`
+- Description: Sampler argument (e.g. ratio)
+
+### HAYHOOKS_TRACING_EXCLUDED_SPANS
+
+- Default: `["send", "receive"]`
+- Description: Low-level ASGI child spans to suppress from FastAPI/Starlette instrumentation. This helps keep traces readable for streaming responses by default.
+- Options:
+  - `["send", "receive"]` (default): suppress both per-chunk response send spans and request receive spans
+  - `["send"]`: keep receive spans, suppress response send spans
+  - `[]`: disable this filtering and keep all framework spans
+
+!!! note "No Hayhooks-specific OTel env vars"
+    Hayhooks does not introduce a custom `HAYHOOKS_OTEL_*` exporter/provider namespace. Use standard OpenTelemetry
+    variables for backend configuration. `HAYHOOKS_TRACING_EXCLUDED_SPANS` is a Hayhooks-specific instrumentation tuning
+    setting for framework span noise, not an OpenTelemetry exporter setting.
+
+When `OTEL_EXPORTER_OTLP_ENDPOINT` (or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`) is set, Hayhooks will also attempt
+an automatic OpenTelemetry bootstrap at startup using the protocol from `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`
+(falling back to `OTEL_EXPORTER_OTLP_PROTOCOL`)
+(`http/protobuf` default, or `grpc`).
+
+### Recommended OSS stack (local and small deployments)
+
+#### Option A: SigNoz (recommended UI)
+
+SigNoz provides a richer trace-exploration UI while staying fully open source.
+
+Start SigNoz locally:
+
+```bash
+git clone -b main https://github.com/SigNoz/signoz.git
+cd signoz/deploy/docker
+docker compose up -d --remove-orphans
+```
+
+Then point Hayhooks/OpenTelemetry to the SigNoz collector:
+
+```bash
+export OTEL_SERVICE_NAME=hayhooks
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_TRACES_SAMPLER=parentbased_traceidratio
+export OTEL_TRACES_SAMPLER_ARG=1.0
+export HAYHOOKS_TRACING_EXCLUDED_SPANS='["send", "receive"]'
+```
+
+Open SigNoz at `http://localhost:8080`, then go to **Traces** and filter by service `hayhooks`.
+
+#### Option B: Jaeger (minimal setup)
+
+If you want a lighter single-container setup:
+
+```bash
+docker run --rm -d \
+  --name jaeger \
+  -e COLLECTOR_OTLP_ENABLED=true \
+  -p 16686:16686 \
+  -p 4318:4318 \
+  jaegertracing/all-in-one:latest
+```
+
+Use the same `OTEL_*` variables shown above and open Jaeger at `http://localhost:16686`.
+
+For advanced setups, you can still initialize your own OpenTelemetry SDK tracer provider before importing
+Hayhooks/Haystack and Hayhooks will use that configured provider.
 
 ## Usage Examples
 

--- a/docs/reference/logging.md
+++ b/docs/reference/logging.md
@@ -45,7 +45,7 @@ HAYHOOKS_LOG_LEVEL=DEBUG hayhooks run
 - **Default**: `INFO`
 - **Alias**: `LOG` (legacy, lower priority)
 - **Description**: Minimum log level to display (consumed by Loguru)
-- **Options**: `DEBUG`, `INFO`, `WARNING`, `ERROR`
+- **Options**: `TRACE`, `DEBUG`, `INFO`, `SUCCESS`, `WARNING`, `ERROR`, `CRITICAL`
 
 #### HAYHOOKS_LOG_FORMAT
 
@@ -67,6 +67,14 @@ HAYHOOKS_LOG_LEVEL=DEBUG hayhooks run
 
 - **Default**: `["uvicorn", "uvicorn.error", "uvicorn.access", "fastapi"]`
 - **Description**: Stdlib loggers routed through Loguru. Only the listed loggers are intercepted; all others keep their default behaviour.
+
+## Trace Correlation
+
+When tracing is enabled, Hayhooks binds `trace_id` and `span_id` to log context for instrumented operations
+(deploy, undeploy, run, OpenAI-compatible execution, MCP tool calls).
+
+- `request_id` is still emitted as before.
+- `trace_id`/`span_id` are normalized to hexadecimal identifiers for easier cross-linking in tracing backends.
 
 ### Custom Log Format
 
@@ -120,7 +128,7 @@ class PipelineWrapper(BasePipelineWrapper):
         result = self.pipeline.run({"prompt": {"query": query}})
 
         execution_time = time.time() - start_time
-        log.info("Pipeline executed in {} seconds", execution_time.round(2))
+        log.info("Pipeline executed in {} seconds", round(execution_time, 2))
 
         return result["llm"]["replies"][0]
 ```

--- a/docs/reference/tracing.md
+++ b/docs/reference/tracing.md
@@ -1,0 +1,73 @@
+# Tracing
+
+Hayhooks tracing builds on Haystack tracing APIs and standard OpenTelemetry configuration.
+
+## Install
+
+Install tracing extras first:
+
+```bash
+pip install "hayhooks[tracing]"
+```
+
+This installs the OpenTelemetry SDK, OTLP exporters, and FastAPI/Starlette instrumentors used by Hayhooks.
+
+## Quick Start (OTLP)
+
+Set OpenTelemetry environment variables, then run Hayhooks:
+
+```bash
+export OTEL_SERVICE_NAME=hayhooks
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_TRACES_SAMPLER=parentbased_traceidratio
+export OTEL_TRACES_SAMPLER_ARG=1.0
+export HAYHOOKS_TRACING_EXCLUDED_SPANS='["send", "receive"]'
+
+hayhooks run
+```
+
+!!! tip "Using OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+    If you set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` directly for HTTP transport, use the full traces path
+    (for example `http://localhost:4318/v1/traces`).
+
+## Local Backends
+
+### SigNoz
+
+Start SigNoz locally:
+
+```bash
+git clone -b main https://github.com/SigNoz/signoz.git
+cd signoz/deploy/docker
+docker compose up -d --remove-orphans
+```
+
+Open SigNoz at `http://localhost:8080`, then go to **Traces** and filter by service `hayhooks`.
+
+### Jaeger
+
+If you want a lighter single-container setup:
+
+```bash
+docker run --rm -d \
+  --name jaeger \
+  -e COLLECTOR_OTLP_ENABLED=true \
+  -p 16686:16686 \
+  -p 4318:4318 \
+  jaegertracing/all-in-one:latest
+```
+
+Open Jaeger at `http://localhost:16686` and use the same `OTEL_*` variables shown above.
+
+## Notes
+
+- Hayhooks does not define a custom `HAYHOOKS_OTEL_*` exporter namespace. Use standard OpenTelemetry `OTEL_*` variables.
+- `HAYHOOKS_TRACING_EXCLUDED_SPANS` is a Hayhooks-specific instrumentation tuning option for framework span noise.
+- When `OTEL_EXPORTER_OTLP_ENDPOINT` (or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`) is set, Hayhooks attempts automatic OTLP bootstrap at startup using `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` (fallback: `OTEL_EXPORTER_OTLP_PROTOCOL`, default `http/protobuf`).
+- For advanced setups, you can initialize your own OpenTelemetry tracer provider before importing Hayhooks/Haystack.
+
+## Next Steps
+
+- [Environment Variables](environment-variables.md)
+- [Logging](logging.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
   - Reference:
     - API Reference: reference/api-reference.md
     - Environment Variables: reference/environment-variables.md
+    - Tracing: reference/tracing.md
     - Logging: reference/logging.md
   - About:
     - License: about/license.md
@@ -130,6 +131,7 @@ plugins:
         Reference:
           - reference/api-reference.md: REST API reference for Haystack Pipelines and Agents endpoints.
           - reference/environment-variables.md: Environment variables and their defaults.
+          - reference/tracing.md: OpenTelemetry tracing setup, local backends, and behavior.
           - reference/logging.md: Logging configuration and observability guidance.
         About:
           - about/license.md: Project licensing details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,13 @@ chainlit = [
   "chainlit>=2.0.0",
   "httpx>=0.27.0",
 ]
+tracing = [
+  "opentelemetry-sdk",
+  "opentelemetry-exporter-otlp-proto-http",
+  "opentelemetry-exporter-otlp-proto-grpc",
+  "opentelemetry-instrumentation-fastapi",
+  "opentelemetry-instrumentation-starlette",
+]
 
 [project.urls]
 Documentation = "https://github.com/deepset-ai/hayhooks#readme"

--- a/src/hayhooks/server/app.py
+++ b/src/hayhooks/server/app.py
@@ -2,6 +2,7 @@ import os
 import sys
 from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
+from contextvars import Context, copy_context
 from functools import lru_cache
 from os import PathLike
 from pathlib import Path
@@ -19,6 +20,13 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from hayhooks.server.logger import RequestIdMiddleware, intercept_stdlib_logging, log, log_elapsed
 from hayhooks.server.routers import deploy_router, draw_router, openai_router, status_router, undeploy_router
+from hayhooks.server.tracing import (
+    SPAN_PIPELINE_STARTUP_DEPLOY,
+    build_trace_tags,
+    configure_tracing,
+    instrument_fastapi_app,
+    trace_operation,
+)
 from hayhooks.server.utils.deploy_utils import (
     commit_prepared_pipeline,
     deploy_pipeline_files,
@@ -142,6 +150,10 @@ def _safe_prepare(path: Path) -> PreparedPipeline | None:
         return None
 
 
+def _prepare_with_context(source: Path, context: Context) -> PreparedPipeline | None:
+    return context.run(_safe_prepare, source)
+
+
 def _deploy_pipelines_parallel(app: FastAPI, yaml_files: list[Path], pipeline_dirs: list[Path]) -> int:
     """
     Deploy pipelines with parallel prepare + serial commit.
@@ -155,7 +167,8 @@ def _deploy_pipelines_parallel(app: FastAPI, yaml_files: list[Path], pipeline_di
     sources: list[Path] = [*yaml_files, *pipeline_dirs]
 
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
-        prepared = [pipeline for pipeline in pool.map(_safe_prepare, sources) if pipeline is not None]
+        contexts = [copy_context() for _ in sources]
+        prepared = [pipeline for pipeline in pool.map(_prepare_with_context, sources, contexts) if pipeline is not None]
 
     deployed = 0
     for p in prepared:
@@ -200,7 +213,19 @@ def deploy_pipelines(app: FastAPI, pipelines_dir: PathLike | str) -> None:
     deploy_fn = _deploy_pipelines_parallel if is_parallel else _deploy_pipelines_sequential
 
     log.info("Deploying {} pipeline(s) using '{}' strategy", total, strategy.value)
-    deployed = deploy_fn(app, yaml_files, pipeline_dirs)
+    with trace_operation(
+        SPAN_PIPELINE_STARTUP_DEPLOY,
+        tags=build_trace_tags(
+            {
+                "hayhooks.transport": "startup",
+                "hayhooks.deploy.strategy": strategy.value,
+                "hayhooks.deploy.total": total,
+                "hayhooks.deploy.workers": settings.startup_deploy_workers if is_parallel else None,
+            }
+        ),
+    ):
+        deployed = deploy_fn(app, yaml_files, pipeline_dirs)
+
     log.info("Startup deploy complete: {}/{} pipelines deployed", deployed, total)
 
 
@@ -263,6 +288,7 @@ def create_app() -> FastAPI:
 
     app = FastAPI(**app_params)
 
+    configure_tracing()
     app.add_middleware(RequestIdMiddleware)
 
     # Check CORS settings before adding middleware
@@ -289,6 +315,8 @@ def create_app() -> FastAPI:
     # Mount Chainlit UI if enabled
     if settings.chainlit_enabled:
         _mount_chainlit_ui(app)
+
+    instrument_fastapi_app(app)
 
     return app
 

--- a/src/hayhooks/server/logger.py
+++ b/src/hayhooks/server/logger.py
@@ -5,7 +5,7 @@ import time
 import uuid
 from collections.abc import Callable
 from functools import wraps
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from loguru import logger as log
 
@@ -90,6 +90,26 @@ class _InterceptHandler(logging.Handler):
 
 def generate_request_id() -> str:
     return uuid.uuid4().hex[:8]
+
+
+# Fixed widths for lower-case hex rendering of OTel correlation IDs.
+_TRACE_ID_HEX_WIDTHS = {"trace_id": 32, "span_id": 16}
+
+
+def _format_trace_identifier(value: Any, width: int) -> str:
+    """Format integer trace/span IDs as fixed-width lower-case hex."""
+    return f"{value:0{width}x}" if isinstance(value, int) else str(value)
+
+
+def normalize_trace_correlation_data(correlation_data: dict[str, Any]) -> dict[str, str]:
+    """Normalize tracer correlation payload for Loguru context fields."""
+    normalized: dict[str, str] = {}
+    for key, value in correlation_data.items():
+        if value is None:
+            continue
+        width = _TRACE_ID_HEX_WIDTHS.get(key)
+        normalized[key] = _format_trace_identifier(value, width) if width else str(value)
+    return normalized
 
 
 class RequestIdMiddleware:

--- a/src/hayhooks/server/routers/openai.py
+++ b/src/hayhooks/server/routers/openai.py
@@ -1,5 +1,6 @@
 import time
 from collections.abc import AsyncGenerator, Generator
+from dataclasses import dataclass
 from typing import Any
 from uuid import uuid4
 
@@ -16,7 +17,47 @@ from haystack.dataclasses import StreamingChunk
 
 from hayhooks.server.logger import log
 from hayhooks.server.pipelines import registry
+from hayhooks.server.tracing import (
+    SPAN_OPENAI_FILE_UPLOAD,
+    SPAN_OPENAI_RUN,
+    build_streaming_trace_tags,
+    build_trace_tags,
+    trace_async_stream,
+    trace_operation,
+    trace_sync_stream,
+)
 from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
+
+
+@dataclass(frozen=True)
+class _OpenAIDispatch:
+    """Describes how to dispatch an OpenAI-compatible call to a pipeline wrapper."""
+
+    operation_kind: str
+    sync_flag: str
+    async_flag: str
+    sync_method: str
+    async_method: str
+    not_implemented_detail: str
+
+
+_CHAT_COMPLETION_DISPATCH = _OpenAIDispatch(
+    operation_kind="run_chat_completion",
+    sync_flag="_is_run_chat_completion_implemented",
+    async_flag="_is_run_chat_completion_async_implemented",
+    sync_method="run_chat_completion",
+    async_method="run_chat_completion_async",
+    not_implemented_detail="Chat endpoint not implemented for this model",
+)
+
+_RESPONSE_DISPATCH = _OpenAIDispatch(
+    operation_kind="run_response",
+    sync_flag="_is_run_response_implemented",
+    async_flag="_is_run_response_async_implemented",
+    sync_method="run_response",
+    async_method="run_response_async",
+    not_implemented_detail="Responses endpoint not implemented for this model",
+)
 
 
 def _list_models() -> list[str]:
@@ -38,80 +79,118 @@ def _collect_sync_generator(gen: Generator) -> str:
 
 async def _collect_async_generator(gen: AsyncGenerator) -> str:
     """Consume an async generator and return the concatenated string content."""
-    chunks = [_chunk_to_text(chunk) async for chunk in gen]
-    return "".join(chunks)
+    return "".join([_chunk_to_text(chunk) async for chunk in gen])
 
 
-async def _run_pipeline_method(  # noqa: PLR0913
-    model: str,
-    kwargs: dict,
-    body: dict,
-    *,
-    sync_flag: str,
-    async_flag: str,
-    sync_method: str,
-    async_method: str,
-    not_implemented_detail: str,
-) -> str | Generator | AsyncGenerator:
-    """Shared dispatch logic for chat completions and responses endpoints."""
+def _resolve_pipeline_wrapper(model: str) -> BasePipelineWrapper:
+    """Look up *model* in the registry, raising 404 if it isn't a pipeline wrapper."""
     pipeline_wrapper = registry.get(model)
     if not isinstance(pipeline_wrapper, BasePipelineWrapper):
         raise HTTPException(status_code=404, detail=f"Pipeline '{model}' not found or not a pipeline wrapper")
+    return pipeline_wrapper
 
-    sync_implemented = getattr(pipeline_wrapper, sync_flag)
-    async_implemented = getattr(pipeline_wrapper, async_flag)
 
-    if not sync_implemented and not async_implemented:
-        raise HTTPException(status_code=501, detail=not_implemented_detail)
+def _select_execution_mode(wrapper: BasePipelineWrapper, dispatch: _OpenAIDispatch) -> tuple[str, str]:
+    """
+    Return the ``(mode, method_name)`` the wrapper should be invoked with.
 
-    if async_implemented:
-        log.debug("Using {} for model: {}", async_method, model)
-        result = await getattr(pipeline_wrapper, async_method)(model=model, **kwargs, body=body)
-    else:
-        log.debug("Using {} (sync) for model: {}", sync_method, model)
-        result = await run_in_threadpool(getattr(pipeline_wrapper, sync_method), model=model, **kwargs, body=body)
+    ``mode`` is ``"async"`` or ``"sync"``. Raises ``HTTPException(501)`` when
+    neither variant is implemented.
+    """
+    if getattr(wrapper, dispatch.async_flag):
+        return "async", dispatch.async_method
+    if getattr(wrapper, dispatch.sync_flag):
+        return "sync", dispatch.sync_method
+    raise HTTPException(status_code=501, detail=dispatch.not_implemented_detail)
 
-    stream_requested = body.get("stream", False)
+
+async def _invoke_pipeline_method(
+    wrapper: BasePipelineWrapper, *, mode: str, method_name: str, model: str, call_kwargs: dict[str, Any]
+) -> Any:
+    """Invoke the resolved pipeline method in either async or threadpool-sync mode."""
+    method = getattr(wrapper, method_name)
+    log.debug("Using {} ({}) for model: {}", method_name, mode, model)
+    if mode == "async":
+        return await method(model=model, **call_kwargs)
+    return await run_in_threadpool(method, model=model, **call_kwargs)
+
+
+def _wrap_string_as_streaming(text: str) -> Generator[StreamingChunk, None, None]:
+    """Adapt a plain string result to the streaming-chunk generator shape."""
+    yield StreamingChunk(content=text)
+
+
+async def _normalize_result(result: Any, *, stream_requested: bool) -> str | Generator | AsyncGenerator:
+    """Normalize the wrapper's return value to what the OpenAI router expects."""
     if not stream_requested:
         if isinstance(result, Generator):
             return _collect_sync_generator(result)
         if isinstance(result, AsyncGenerator):
             return await _collect_async_generator(result)
+        return result
 
-    if stream_requested and isinstance(result, str):
-
-        def _wrap_str_as_generator():
-            yield StreamingChunk(content=result)
-
-        return _wrap_str_as_generator()
-
+    if isinstance(result, str):
+        return _wrap_string_as_streaming(result)
     return result
 
 
-async def _run_completion(model: str, messages: list[dict], body: dict) -> str | Generator | AsyncGenerator:
-    return await _run_pipeline_method(
-        model,
-        {"messages": messages},
-        body,
-        sync_flag="_is_run_chat_completion_implemented",
-        async_flag="_is_run_chat_completion_async_implemented",
-        sync_method="run_chat_completion",
-        async_method="run_chat_completion_async",
-        not_implemented_detail="Chat endpoint not implemented for this model",
+async def _run_pipeline_method(
+    dispatch: _OpenAIDispatch,
+    *,
+    model: str,
+    kwargs: dict[str, Any],
+    body: dict[str, Any],
+) -> str | Generator | AsyncGenerator:
+    """Shared dispatch logic for chat completions and responses endpoints."""
+    stream_requested = bool(body.get("stream", False))
+    trace_tags = build_trace_tags(
+        {
+            "hayhooks.transport": "openai",
+            "hayhooks.openai.operation": dispatch.operation_kind,
+            "hayhooks.pipeline.name": model,
+            "hayhooks.openai.stream_requested": stream_requested,
+        }
     )
+    if stream_requested:
+        try:
+            wrapper = _resolve_pipeline_wrapper(model)
+            mode, method_name = _select_execution_mode(wrapper, dispatch)
+            result = await _invoke_pipeline_method(
+                wrapper, mode=mode, method_name=method_name, model=model, call_kwargs={**kwargs, "body": body}
+            )
+            normalized_result = await _normalize_result(result, stream_requested=stream_requested)
+        except BaseException:
+            with trace_operation(SPAN_OPENAI_RUN, tags=trace_tags):
+                raise
+
+        trace_tags = build_trace_tags(trace_tags, **{"hayhooks.openai.execution_mode": mode})
+        streaming_trace_tags = build_streaming_trace_tags(trace_tags, stream_type="sse")
+        if isinstance(normalized_result, AsyncGenerator):
+            return trace_async_stream(normalized_result, SPAN_OPENAI_RUN, tags=streaming_trace_tags)
+        if isinstance(normalized_result, Generator):
+            return trace_sync_stream(normalized_result, SPAN_OPENAI_RUN, tags=streaming_trace_tags)
+        return normalized_result
+
+    with trace_operation(SPAN_OPENAI_RUN, tags=trace_tags) as span:
+        wrapper = _resolve_pipeline_wrapper(model)
+        mode, method_name = _select_execution_mode(wrapper, dispatch)
+        span.set_tag("hayhooks.openai.execution_mode", mode)
+        result = await _invoke_pipeline_method(
+            wrapper, mode=mode, method_name=method_name, model=model, call_kwargs={**kwargs, "body": body}
+        )
+        return await _normalize_result(result, stream_requested=stream_requested)
 
 
-async def _run_response(model: str, input_items: list[dict], body: dict) -> str | Generator | AsyncGenerator:
-    return await _run_pipeline_method(
-        model,
-        {"input_items": input_items},
-        body,
-        sync_flag="_is_run_response_implemented",
-        async_flag="_is_run_response_async_implemented",
-        sync_method="run_response",
-        async_method="run_response_async",
-        not_implemented_detail="Responses endpoint not implemented for this model",
-    )
+async def _run_completion(
+    model: str, messages: list[dict[str, Any]], body: dict[str, Any]
+) -> str | Generator | AsyncGenerator:
+    return await _run_pipeline_method(_CHAT_COMPLETION_DISPATCH, model=model, kwargs={"messages": messages}, body=body)
+
+
+async def _run_response(
+    model: str, input_items: list[dict[str, Any]], body: dict[str, Any]
+) -> str | Generator | AsyncGenerator:
+    return await _run_pipeline_method(_RESPONSE_DISPATCH, model=model, kwargs={"input_items": input_items}, body=body)
 
 
 def _find_file_upload_wrapper() -> BasePipelineWrapper | None:
@@ -124,35 +203,47 @@ def _find_file_upload_wrapper() -> BasePipelineWrapper | None:
 
 
 async def _run_file_upload(filename: str | None, content_type: str | None, content: bytes, purpose: str) -> FileObject:
-    wrapper = _find_file_upload_wrapper()
-    if wrapper is not None:
-        result = await run_in_threadpool(wrapper.run_file_upload, filename, content_type, content, purpose)
-        if isinstance(result, FileObject):
-            return result
-        if isinstance(result, dict):
-            return FileObject.model_validate(result)
-        log.error(
-            "run_file_upload returned unsupported type {} from wrapper {!r}",
-            type(result).__name__,
-            wrapper,
-        )
-        raise HTTPException(status_code=500, detail="run_file_upload returned an unsupported type")
+    with trace_operation(
+        SPAN_OPENAI_FILE_UPLOAD,
+        tags=build_trace_tags(
+            {
+                "hayhooks.transport": "openai",
+                "hayhooks.openai.operation": "file_upload",
+                "hayhooks.openai.file.content_type": content_type,
+                "hayhooks.openai.file.purpose": purpose,
+                "hayhooks.openai.file.size_bytes": len(content),
+            }
+        ),
+    ):
+        wrapper = _find_file_upload_wrapper()
+        if wrapper is not None:
+            result = await run_in_threadpool(wrapper.run_file_upload, filename, content_type, content, purpose)
+            if isinstance(result, FileObject):
+                return result
+            if isinstance(result, dict):
+                return FileObject.model_validate(result)
+            log.error(
+                "run_file_upload returned unsupported type {} from wrapper {!r}",
+                type(result).__name__,
+                wrapper,
+            )
+            raise HTTPException(status_code=500, detail="run_file_upload returned an unsupported type")
 
-    file_id = f"file-{uuid4().hex[:24]}"
-    log.warning(
-        "No pipeline implements run_file_upload: file '{}' (id={}) not persisted. "
-        "Override run_file_upload in your PipelineWrapper to store files.",
-        filename,
-        file_id,
-    )
-    return FileObject(
-        id=file_id,
-        object="file",
-        bytes=len(content),
-        created_at=int(time.time()),
-        filename=filename or "",
-        purpose=purpose,
-    )
+        file_id = f"file-{uuid4().hex[:24]}"
+        log.warning(
+            "No pipeline implements run_file_upload: file '{}' (id={}) not persisted. "
+            "Override run_file_upload in your PipelineWrapper to store files.",
+            filename,
+            file_id,
+        )
+        return FileObject(
+            id=file_id,
+            object="file",
+            bytes=len(content),
+            created_at=int(time.time()),
+            filename=filename or "",
+            purpose=purpose,
+        )
 
 
 router = APIRouter()

--- a/src/hayhooks/server/tracing.py
+++ b/src/hayhooks/server/tracing.py
@@ -1,0 +1,481 @@
+"""
+OpenTelemetry / Haystack tracing integration for Hayhooks.
+
+This module centralizes:
+  - Span-name constants used throughout the server.
+  - Opt-in FastAPI / Starlette OpenTelemetry instrumentation (via Haystack's
+    ``LazyImport`` so the ``tracing`` extra stays optional).
+  - A small :func:`trace_operation` context manager that every Hayhooks
+    domain span flows through, with consistent success / error / timing tags
+    and Loguru log correlation.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncGenerator, Generator, Iterator, Mapping
+from contextlib import contextmanager, nullcontext
+from contextvars import copy_context
+from time import monotonic
+from typing import Any
+
+from fastapi import HTTPException
+from haystack.lazy_imports import LazyImport
+from haystack.tracing import OpenTelemetryTracer, auto_enable_tracing, enable_tracing, is_tracing_enabled, tracer
+
+from hayhooks.server.logger import log, normalize_trace_correlation_data
+from hayhooks.settings import settings
+
+_TRACING_EXTRA_INSTALL_CMD = 'pip install "hayhooks[tracing]"'
+_LAZY_IMPORT_HINT = f"Run '{_TRACING_EXTRA_INSTALL_CMD}' to install tracing support."
+_INSTALL_HINT = f"Install with '{_TRACING_EXTRA_INSTALL_CMD}'."
+
+SPAN_PIPELINE_DEPLOY = "hayhooks.pipeline.deploy"
+SPAN_PIPELINE_DEPLOY_PREPARE = "hayhooks.pipeline.deploy.prepare"
+SPAN_PIPELINE_DEPLOY_COMMIT = "hayhooks.pipeline.deploy.commit"
+SPAN_PIPELINE_UNDEPLOY = "hayhooks.pipeline.undeploy"
+SPAN_PIPELINE_RUN = "hayhooks.pipeline.run"
+SPAN_PIPELINE_STARTUP_DEPLOY = "hayhooks.pipeline.startup.deploy"
+SPAN_OPENAI_RUN = "hayhooks.openai.run"
+SPAN_OPENAI_FILE_UPLOAD = "hayhooks.openai.file_upload"
+SPAN_MCP_LIST_TOOLS = "hayhooks.mcp.list_tools"
+SPAN_MCP_CALL_TOOL = "hayhooks.mcp.call_tool"
+SPAN_MCP_RUN_PIPELINE_TOOL = "hayhooks.mcp.run_pipeline_tool"
+
+_TAG_SUCCESS = "hayhooks.success"
+_TAG_ERROR_TYPE = "hayhooks.error.type"
+_TAG_ELAPSED_MS = "hayhooks.elapsed_ms"
+_TAG_HTTP_STATUS = "hayhooks.http.status_code"
+_TAG_RESPONSE_STREAMING = "hayhooks.response.streaming"
+_TAG_RESPONSE_STREAM_TYPE = "hayhooks.response.stream_type"
+
+_FASTAPI_STATE_FLAG = "_hayhooks_fastapi_instrumented"
+_STARLETTE_STATE_FLAG = "_hayhooks_starlette_instrumented"
+_DEFAULT_SERVICE_NAME = "hayhooks"
+_OTLP_HTTP_PROTOBUF = "http/protobuf"
+_OTLP_GRPC = "grpc"
+_OTLP_ENDPOINT_ENV_KEYS = ("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "OTEL_EXPORTER_OTLP_ENDPOINT")
+_OTLP_PROTOCOL_ENV_KEYS = ("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "OTEL_EXPORTER_OTLP_PROTOCOL")
+
+with LazyImport(_LAZY_IMPORT_HINT) as fastapi_tracing_import:
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor  # ty: ignore[unresolved-import]
+
+with LazyImport(_LAZY_IMPORT_HINT) as starlette_tracing_import:
+    from opentelemetry.instrumentation.starlette import StarletteInstrumentor  # ty: ignore[unresolved-import]
+
+with LazyImport(_LAZY_IMPORT_HINT) as otel_sdk_import:
+    from opentelemetry import trace as otel_trace  # ty: ignore[unresolved-import]
+    from opentelemetry.sdk.resources import SERVICE_NAME, Resource  # ty: ignore[unresolved-import]
+    from opentelemetry.sdk.trace import TracerProvider  # ty: ignore[unresolved-import]
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor  # ty: ignore[unresolved-import]
+
+with LazyImport(_LAZY_IMPORT_HINT) as otlp_http_exporter_import:
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import (  # ty: ignore[unresolved-import]
+        OTLPSpanExporter as OTLPHTTPSpanExporter,
+    )
+
+with LazyImport(_LAZY_IMPORT_HINT) as otlp_grpc_exporter_import:
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (  # ty: ignore[unresolved-import]
+        OTLPSpanExporter as OTLPGRPCSpanExporter,
+    )
+
+
+def _first_set_env(*keys: str) -> str | None:
+    for key in keys:
+        if value := os.getenv(key):
+            return value
+    return None
+
+
+def _normalize_otlp_protocol(raw_protocol: str | None) -> str | None:
+    if raw_protocol is None:
+        return _OTLP_HTTP_PROTOBUF
+
+    normalized = raw_protocol.strip().lower()
+    if normalized in {"http", _OTLP_HTTP_PROTOBUF}:
+        return _OTLP_HTTP_PROTOBUF
+    if normalized == _OTLP_GRPC:
+        return _OTLP_GRPC
+    return None
+
+
+def _load_fastapi_instrumentor() -> type[Any] | None:
+    """Return FastAPI OTel instrumentor when tracing extras are installed."""
+    try:
+        fastapi_tracing_import.check()
+    except ImportError:
+        return None
+    return FastAPIInstrumentor
+
+
+def _load_starlette_instrumentor() -> type[Any] | None:
+    """Return Starlette OTel instrumentor when tracing extras are installed."""
+    try:
+        starlette_tracing_import.check()
+    except ImportError:
+        return None
+    return StarletteInstrumentor
+
+
+def _build_otlp_span_exporter(protocol: str) -> Any | None:
+    if protocol == _OTLP_HTTP_PROTOBUF:
+        try:
+            otlp_http_exporter_import.check()
+        except ImportError:
+            log.warning(
+                "OTLP HTTP exporter unavailable. {} "
+                "Reinstall tracing extras to ensure OTLP exporter dependencies are installed.",
+                _INSTALL_HINT,
+            )
+            return None
+        # Let the exporter resolve endpoint/path from standard OTEL env vars.
+        # This avoids accidentally overriding path handling (e.g. /v1/traces).
+        return OTLPHTTPSpanExporter()
+
+    if protocol == _OTLP_GRPC:
+        try:
+            otlp_grpc_exporter_import.check()
+        except ImportError:
+            log.warning(
+                "OTLP gRPC exporter unavailable. {} Install with: pip install opentelemetry-exporter-otlp-proto-grpc",
+                _INSTALL_HINT,
+            )
+            return None
+        return OTLPGRPCSpanExporter()
+
+    log.warning(
+        "OTLP protocol '{}' is not supported by Hayhooks built-in tracing bootstrap. "
+        "Supported protocols are '{}' and '{}'.",
+        protocol,
+        _OTLP_HTTP_PROTOBUF,
+        _OTLP_GRPC,
+    )
+    return None
+
+
+def _configure_otel_tracer_from_env() -> bool:
+    """
+    Bootstrap OpenTelemetry tracing when OTLP endpoint vars are present.
+
+    This gives Hayhooks a sensible out-of-the-box path for local/self-hosted
+    tracing setups without requiring users to write explicit SDK bootstrap code.
+    """
+    endpoint = _first_set_env(*_OTLP_ENDPOINT_ENV_KEYS)
+    if endpoint is None:
+        return False
+
+    raw_protocol = _first_set_env(*_OTLP_PROTOCOL_ENV_KEYS)
+    protocol = _normalize_otlp_protocol(raw_protocol)
+    if protocol is None:
+        log.warning(
+            "OTLP protocol '{}' is not supported by Hayhooks built-in tracing bootstrap. "
+            "Supported values are: {}, {}, {}.",
+            raw_protocol,
+            "http",
+            _OTLP_HTTP_PROTOBUF,
+            _OTLP_GRPC,
+        )
+        return False
+
+    try:
+        otel_sdk_import.check()
+    except ImportError:
+        log.warning(
+            "OpenTelemetry OTLP runtime unavailable. {} "
+            "If you upgraded Hayhooks, reinstall extras to pull new tracing dependencies.",
+            _INSTALL_HINT,
+        )
+        return False
+
+    exporter = _build_otlp_span_exporter(protocol)
+    if exporter is None:
+        return False
+
+    try:
+        service_name = os.getenv("OTEL_SERVICE_NAME", _DEFAULT_SERVICE_NAME)
+        provider = TracerProvider(resource=Resource.create({SERVICE_NAME: service_name}))
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+        otel_trace.set_tracer_provider(provider)
+        enable_tracing(OpenTelemetryTracer(otel_trace.get_tracer(service_name)))
+    except Exception as exc:  # pragma: no cover - defensive guard for SDK/runtime failures
+        log.warning("Failed to bootstrap OpenTelemetry tracing from environment: {}", exc)
+        return False
+
+    log.info("Hayhooks tracing enabled with OTLP {} exporter endpoint '{}'", protocol, endpoint)
+    return True
+
+
+def configure_tracing() -> bool:
+    """
+    Ensure Haystack tracing is enabled when possible.
+
+    Order:
+      1. No-op if tracing is already enabled.
+      2. Try Haystack's ``auto_enable_tracing()`` for externally configured providers.
+      3. Fallback to Hayhooks OTLP bootstrap when OTLP env vars are present.
+    """
+    if is_tracing_enabled():
+        return True
+
+    auto_enable_tracing()
+    if is_tracing_enabled():
+        log.debug("Hayhooks tracing enabled by Haystack auto-configuration")
+        return True
+
+    return _configure_otel_tracer_from_env()
+
+
+def _instrument_app(
+    app: Any,
+    *,
+    state_attr: str,
+    instrumentor: type[Any] | None,
+    framework_name: str,
+) -> bool:
+    """Attach *instrumentor* to *app* exactly once. Returns ``True`` on success."""
+    if getattr(app.state, state_attr, False):
+        return True
+
+    if instrumentor is None:
+        log.debug("OpenTelemetry {} instrumentation unavailable. {}", framework_name, _INSTALL_HINT)
+        return False
+
+    try:
+        instrument_kwargs: dict[str, Any] = {}
+        if settings.tracing_excluded_spans:
+            instrument_kwargs["exclude_spans"] = settings.tracing_excluded_spans
+        try:
+            instrumentor.instrument_app(app, **instrument_kwargs)
+        except TypeError as exc:
+            if instrument_kwargs and "exclude_spans" in str(exc):
+                log.debug(
+                    "{} instrumentation does not support exclude_spans; retrying without excluded span filtering",
+                    framework_name,
+                )
+                instrumentor.instrument_app(app)
+            else:
+                raise
+    except Exception as exc:  # pragma: no cover - defensive guard for third-party errors
+        log.warning("Failed to instrument {} app with OpenTelemetry: {}", framework_name, exc)
+        return False
+
+    setattr(app.state, state_attr, True)
+    log.debug("OpenTelemetry {} instrumentation enabled", framework_name)
+    return True
+
+
+def instrument_fastapi_app(app: Any) -> bool:
+    """
+    Enable OpenTelemetry FastAPI instrumentation for *app* if available.
+
+    Returns ``True`` when instrumentation is enabled or already active.
+    """
+    return _instrument_app(
+        app,
+        state_attr=_FASTAPI_STATE_FLAG,
+        instrumentor=_load_fastapi_instrumentor(),
+        framework_name="FastAPI",
+    )
+
+
+def instrument_starlette_app(app: Any) -> bool:
+    """
+    Enable OpenTelemetry Starlette instrumentation for *app* if available.
+
+    Returns ``True`` when instrumentation is enabled or already active.
+    """
+    return _instrument_app(
+        app,
+        state_attr=_STARLETTE_STATE_FLAG,
+        instrumentor=_load_starlette_instrumentor(),
+        framework_name="Starlette",
+    )
+
+
+def build_trace_tags(tags: Mapping[str, Any] | None = None, **kwargs: Any) -> dict[str, Any]:
+    """
+    Merge tag mappings and drop keys whose value is ``None``.
+
+    ``None`` values are skipped so optional attributes don't pollute spans with
+    empty fields. Keyword arguments override values from ``tags``.
+    """
+    merged: dict[str, Any] = {**(tags or {}), **kwargs}
+    return {key: value for key, value in merged.items() if value is not None}
+
+
+def build_streaming_trace_tags(tags: Mapping[str, Any] | None = None, *, stream_type: str) -> dict[str, Any]:
+    return build_trace_tags(tags, **{_TAG_RESPONSE_STREAMING: True, _TAG_RESPONSE_STREAM_TYPE: stream_type})
+
+
+def get_trace_log_context() -> dict[str, str]:
+    """
+    Return normalized trace correlation values for Loguru ``contextualize``.
+
+    Returns an empty dict when tracing is disabled or correlation data is unavailable.
+    """
+    current_span = tracer.current_span()
+    if current_span is None:
+        return {}
+
+    try:
+        correlation_data = current_span.get_correlation_data_for_logs()
+    except Exception:  # pragma: no cover - defensive guard for third-party tracer errors
+        return {}
+
+    return normalize_trace_correlation_data(correlation_data) if correlation_data else {}
+
+
+def _mark_success(span: Any) -> None:
+    span.set_tag(_TAG_SUCCESS, value=True)
+
+
+def _mark_failure(span: Any, exc: BaseException) -> None:
+    span.set_tag(_TAG_SUCCESS, value=False)
+    span.set_tag(_TAG_ERROR_TYPE, type(exc).__name__)
+
+
+def _mark_http_exception(span: Any, exc: HTTPException) -> None:
+    """
+    Record an HTTPException outcome.
+
+    Domain-operation spans treat every HTTPException as a failure while still
+    recording the HTTP status code for debugging and transport correlation.
+    """
+    span.set_tag(_TAG_HTTP_STATUS, exc.status_code)
+    _mark_failure(span, exc)
+
+
+class _OperationTrace:
+    def __init__(self, operation_name: str, *, tags: Mapping[str, Any] | None = None):
+        self._span_cm = tracer.trace(operation_name, tags=dict(tags or {}))
+        self._span: Any | None = None
+        self._log_context_cm: Any | None = None
+        self._started = 0.0
+        self._finished = False
+
+    @property
+    def span(self) -> Any:
+        return self.start()
+
+    def start(self) -> Any:
+        if self._span is not None:
+            return self._span
+
+        self._span = self._span_cm.__enter__()
+        self._started = monotonic()
+        trace_context = get_trace_log_context()
+        self._log_context_cm = log.contextualize(**trace_context) if trace_context else nullcontext()
+        self._log_context_cm.__enter__()
+        return self._span
+
+    def finish(self, exc: BaseException | None = None) -> None:
+        span = self.start()
+        if self._finished:
+            return
+
+        try:
+            if exc is None:
+                _mark_success(span)
+            elif isinstance(exc, HTTPException):
+                _mark_http_exception(span, exc)
+            else:
+                _mark_failure(span, exc)
+        finally:
+            span.set_tag(_TAG_ELAPSED_MS, (monotonic() - self._started) * 1000)
+            exc_type = type(exc) if exc is not None else None
+            exc_tb = exc.__traceback__ if exc is not None else None
+            if self._log_context_cm is not None:
+                self._log_context_cm.__exit__(exc_type, exc, exc_tb)
+            self._span_cm.__exit__(exc_type, exc, exc_tb)
+            self._finished = True
+
+
+def start_trace_operation(
+    operation_name: str,
+    *,
+    tags: Mapping[str, Any] | None = None,
+) -> _OperationTrace:
+    operation = _OperationTrace(operation_name, tags=tags)
+    operation.start()
+    return operation
+
+
+def trace_sync_stream(
+    stream: Generator[Any, None, None],
+    operation_name: str,
+    *,
+    tags: Mapping[str, Any] | None = None,
+) -> Generator[Any, None, None]:
+    operation = _OperationTrace(operation_name, tags=tags)
+    stream_context = copy_context()
+
+    def traced_stream() -> Generator[Any, None, None]:
+        stream_context.run(operation.start)
+        try:
+            while True:
+                try:
+                    item = stream_context.run(next, stream)
+                except StopIteration:
+                    stream_context.run(operation.finish)
+                    return
+                except BaseException as exc:
+                    stream_context.run(operation.finish, exc)
+                    raise
+                else:
+                    yield item
+        except BaseException as exc:
+            stream_context.run(operation.finish, exc)
+            raise
+        finally:
+            close = getattr(stream, "close", None)
+            if callable(close):
+                stream_context.run(close)
+
+    return traced_stream()
+
+
+def trace_async_stream(
+    stream: AsyncGenerator[Any, None],
+    operation_name: str,
+    *,
+    tags: Mapping[str, Any] | None = None,
+) -> AsyncGenerator[Any, None]:
+    async def traced_stream() -> AsyncGenerator[Any, None]:
+        try:
+            with trace_operation(operation_name, tags=tags):
+                async for item in stream:
+                    yield item
+        finally:
+            aclose = getattr(stream, "aclose", None)
+            if callable(aclose):
+                await aclose()
+
+    return traced_stream()
+
+
+@contextmanager
+def trace_operation(
+    operation_name: str,
+    *,
+    tags: Mapping[str, Any] | None = None,
+) -> Iterator[Any]:
+    """
+    Wrap a block in a Haystack span and attach standard Hayhooks attributes.
+
+    On exit the span is tagged with:
+      - ``hayhooks.success`` (``bool``)
+      - ``hayhooks.error.type`` (only on failure)
+      - ``hayhooks.http.status_code`` (only for :class:`HTTPException`)
+      - ``hayhooks.elapsed_ms`` (wall-clock duration)
+
+    The wrapped block also inherits ``trace_id`` / ``span_id`` in its Loguru
+    log context so logs emitted inside it can be correlated with the span.
+    """
+    operation = start_trace_operation(operation_name, tags=tags)
+    try:
+        yield operation.span
+    except BaseException as exc:
+        operation.finish(exc)
+        raise
+    else:
+        operation.finish()

--- a/src/hayhooks/server/utils/deploy_utils.py
+++ b/src/hayhooks/server/utils/deploy_utils.py
@@ -5,15 +5,15 @@ import tempfile
 import threading
 import time
 import traceback
-from collections.abc import Callable
+from collections.abc import AsyncGenerator, Callable, Generator
 from functools import wraps
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import docstring_parser
 from fastapi import FastAPI, Form, HTTPException
 from fastapi.concurrency import run_in_threadpool
-from fastapi.responses import Response
+from fastapi.responses import Response, StreamingResponse
 from fastapi.routing import APIRoute
 from pydantic import BaseModel
 
@@ -24,6 +24,19 @@ from hayhooks.server.pipelines.models import (
     create_request_model_from_callable,
     create_response_model_from_callable,
     get_response_class_from_callable,
+)
+from hayhooks.server.pipelines.sse import SSEStream
+from hayhooks.server.tracing import (
+    SPAN_PIPELINE_DEPLOY,
+    SPAN_PIPELINE_DEPLOY_COMMIT,
+    SPAN_PIPELINE_DEPLOY_PREPARE,
+    SPAN_PIPELINE_RUN,
+    SPAN_PIPELINE_UNDEPLOY,
+    build_streaming_trace_tags,
+    build_trace_tags,
+    trace_async_stream,
+    trace_operation,
+    trace_sync_stream,
 )
 from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
 from hayhooks.server.utils.models import PreparedPipeline
@@ -225,6 +238,67 @@ async def _execute_pipeline_run(
     return await run_in_threadpool(pipeline_wrapper.run_api, **payload)
 
 
+def _build_run_trace_tags(pipeline_name: str, payload: dict[str, Any]) -> dict[str, Any]:
+    return build_trace_tags(
+        {
+            "hayhooks.transport": "rest",
+            "hayhooks.pipeline.name": pipeline_name,
+            "hayhooks.route": f"/{pipeline_name}/run",
+            "hayhooks.payload.keys": sorted(payload.keys()),
+            "hayhooks.payload.has_files": "files" in payload,
+        }
+    )
+
+
+async def _execute_pipeline_run_with_tracing(
+    pipeline_wrapper: BasePipelineWrapper,
+    payload: dict[str, Any],
+    *,
+    trace_tags: dict[str, Any],
+    is_streaming_response: bool,
+) -> Any:
+    if is_streaming_response:
+        try:
+            return await _execute_pipeline_run(pipeline_wrapper, payload)
+        except BaseException:
+            with trace_operation(SPAN_PIPELINE_RUN, tags=trace_tags):
+                raise
+
+    with trace_operation(SPAN_PIPELINE_RUN, tags=trace_tags):
+        return await _execute_pipeline_run(pipeline_wrapper, payload)
+
+
+def _trace_streaming_run_result(result: Any, trace_tags: dict[str, Any]) -> Any:
+    if isinstance(result, SSEStream):
+        if isinstance(result.stream, AsyncGenerator):
+            return SSEStream(
+                trace_async_stream(
+                    result.stream,
+                    SPAN_PIPELINE_RUN,
+                    tags=build_streaming_trace_tags(trace_tags, stream_type="sse"),
+                )
+            )
+        if isinstance(result.stream, Generator):
+            return SSEStream(
+                trace_sync_stream(
+                    result.stream,
+                    SPAN_PIPELINE_RUN,
+                    tags=build_streaming_trace_tags(trace_tags, stream_type="sse"),
+                )
+            )
+        return result
+
+    if isinstance(result, AsyncGenerator):
+        return trace_async_stream(
+            result, SPAN_PIPELINE_RUN, tags=build_streaming_trace_tags(trace_tags, stream_type="plain")
+        )
+    if isinstance(result, Generator):
+        return trace_sync_stream(
+            result, SPAN_PIPELINE_RUN, tags=build_streaming_trace_tags(trace_tags, stream_type="plain")
+        )
+    return result
+
+
 def create_run_endpoint_handler(
     pipeline_wrapper: BasePipelineWrapper,
     pipeline_name: str,
@@ -250,16 +324,28 @@ def create_run_endpoint_handler(
     Returns:
         A FastAPI endpoint function that executes the pipeline and returns the response model.
     """
+    run_method = (
+        pipeline_wrapper.run_api_async if pipeline_wrapper._is_run_api_async_implemented else pipeline_wrapper.run_api
+    )
+    is_streaming_response = get_response_class_from_callable(run_method) is StreamingResponse
 
     async def _handle_request(run_req: BaseModel) -> Response | BaseModel:
         payload = run_req.model_dump()
+        trace_tags = _build_run_trace_tags(pipeline_name, payload)
 
         log.bind(params=payload).opt(colors=True).info("Running pipeline '<bold>{}</bold>'", pipeline_name)
         t0 = time.monotonic()
-        result = await _execute_pipeline_run(pipeline_wrapper, payload)
+        result = await _execute_pipeline_run_with_tracing(
+            pipeline_wrapper,
+            payload,
+            trace_tags=trace_tags,
+            is_streaming_response=is_streaming_response,
+        )
         elapsed_ms = (time.monotonic() - t0) * 1000
 
-        streaming_response = _streaming_response_from_result(result)
+        traced_result = _trace_streaming_run_result(result, trace_tags)
+
+        streaming_response = _streaming_response_from_result(traced_result)
         if streaming_response is not None:
             log.opt(colors=True).info(
                 "Pipeline '<bold>{}</bold>' streaming response started (<bold>{:.0f}ms</bold>)",
@@ -278,9 +364,9 @@ def create_run_endpoint_handler(
         # _streaming_response_from_result() always handles the result above.
         # For normal JSON endpoints, wrap the result in the Pydantic response model.
         if response_model is None:
-            return result
+            return cast(Response | BaseModel, traced_result)
 
-        return response_model(result=result)
+        return cast(Response | BaseModel, response_model(result=traced_result))
 
     @handle_pipeline_exceptions()
     async def run_endpoint_with_files(
@@ -504,24 +590,36 @@ def prepare_pipeline_files(
     expensive work that is safe to run in a thread.  The returned
     ``PreparedPipeline`` can be committed later via ``_register_and_deploy_pipeline``.
     """
-    tmp_dir = None
+    with trace_operation(
+        SPAN_PIPELINE_DEPLOY_PREPARE,
+        tags=build_trace_tags(
+            {
+                "hayhooks.transport": "runtime",
+                "hayhooks.pipeline.name": pipeline_name,
+                "hayhooks.pipeline.source_type": "files",
+                "hayhooks.deploy.save_files": save_files,
+                "hayhooks.deploy.file_count": len(files),
+            }
+        ),
+    ):
+        tmp_dir = None
 
-    if save_files:
-        save_pipeline_files(pipeline_name, files=files, pipelines_dir=settings.pipelines_dir)
-        pipeline_dir = Path(settings.pipelines_dir) / pipeline_name
-    else:
-        tmp_dir = tempfile.mkdtemp()
-        save_pipeline_files(pipeline_name, files=files, pipelines_dir=tmp_dir)
-        pipeline_dir = Path(tmp_dir) / pipeline_name
+        if save_files:
+            save_pipeline_files(pipeline_name, files=files, pipelines_dir=settings.pipelines_dir)
+            pipeline_dir = Path(settings.pipelines_dir) / pipeline_name
+        else:
+            tmp_dir = tempfile.mkdtemp()
+            save_pipeline_files(pipeline_name, files=files, pipelines_dir=tmp_dir)
+            pipeline_dir = Path(tmp_dir) / pipeline_name
 
-    try:
-        module = load_pipeline_module(pipeline_name, dir_path=pipeline_dir)
-        pipeline_wrapper = create_pipeline_wrapper_instance(module)
-        pipeline_wrapper.setup()
-        return PreparedPipeline(name=pipeline_name, wrapper=pipeline_wrapper)
-    finally:
-        if tmp_dir is not None:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
+        try:
+            module = load_pipeline_module(pipeline_name, dir_path=pipeline_dir)
+            pipeline_wrapper = create_pipeline_wrapper_instance(module)
+            pipeline_wrapper.setup()
+            return PreparedPipeline(name=pipeline_name, wrapper=pipeline_wrapper)
+        finally:
+            if tmp_dir is not None:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 @log_elapsed()
@@ -537,25 +635,36 @@ def prepare_pipeline_yaml(
     expensive work that is safe to run in a thread.
     """
     save_file: bool = True if options is None else bool(options.get("save_file", True))
-    if save_file:
-        save_pipeline_files(pipeline_name, {f"{pipeline_name}.yml": source_code}, settings.pipelines_dir)
-
     description = (options or {}).get("description")
-    pipeline_wrapper = YAMLPipelineWrapper.from_yaml(source_code, description=description)
+    skip_mcp = bool((options or {}).get("skip_mcp", False))
 
-    skip_mcp = (options or {}).get("skip_mcp", False)
-    pipeline_wrapper.skip_mcp = bool(skip_mcp)
+    with trace_operation(
+        SPAN_PIPELINE_DEPLOY_PREPARE,
+        tags=build_trace_tags(
+            {
+                "hayhooks.transport": "runtime",
+                "hayhooks.pipeline.name": pipeline_name,
+                "hayhooks.pipeline.source_type": "yaml",
+                "hayhooks.deploy.save_file": save_file,
+                "hayhooks.deploy.skip_mcp": skip_mcp,
+            }
+        ),
+    ):
+        if save_file:
+            save_pipeline_files(pipeline_name, {f"{pipeline_name}.yml": source_code}, settings.pipelines_dir)
 
-    pipeline_wrapper.setup()
+        pipeline_wrapper = YAMLPipelineWrapper.from_yaml(source_code, description=description)
+        pipeline_wrapper.skip_mcp = skip_mcp
+        pipeline_wrapper.setup()
 
-    extra_metadata = {
-        "description": description or pipeline_name,
-        "streaming_components": pipeline_wrapper.streaming_components,
-        "include_outputs_from": pipeline_wrapper.include_outputs_from,
-        "input_resolutions": pipeline_wrapper.input_resolutions,
-    }
+        extra_metadata = {
+            "description": description or pipeline_name,
+            "streaming_components": pipeline_wrapper.streaming_components,
+            "include_outputs_from": pipeline_wrapper.include_outputs_from,
+            "input_resolutions": pipeline_wrapper.input_resolutions,
+        }
 
-    return PreparedPipeline(name=pipeline_name, wrapper=pipeline_wrapper, extra_metadata=extra_metadata)
+        return PreparedPipeline(name=pipeline_name, wrapper=pipeline_wrapper, extra_metadata=extra_metadata)
 
 
 def commit_prepared_pipeline(
@@ -570,14 +679,26 @@ def commit_prepared_pipeline(
 
     This mutates shared state and must NOT be called concurrently.
     """
-    return _register_and_deploy_pipeline(
-        pipeline_name=prepared.name,
-        pipeline_wrapper=prepared.wrapper,
-        app=app,
-        overwrite=overwrite,
-        extra_metadata=prepared.extra_metadata,
-        _defer_openapi_rebuild=_defer_openapi_rebuild,
-    )
+    with trace_operation(
+        SPAN_PIPELINE_DEPLOY_COMMIT,
+        tags=build_trace_tags(
+            {
+                "hayhooks.transport": "runtime",
+                "hayhooks.pipeline.name": prepared.name,
+                "hayhooks.deploy.overwrite": overwrite,
+                "hayhooks.deploy.with_fastapi_route": app is not None,
+                "hayhooks.deploy.defer_openapi_rebuild": _defer_openapi_rebuild,
+            }
+        ),
+    ):
+        return _register_and_deploy_pipeline(
+            pipeline_name=prepared.name,
+            pipeline_wrapper=prepared.wrapper,
+            app=app,
+            overwrite=overwrite,
+            extra_metadata=prepared.extra_metadata,
+            _defer_openapi_rebuild=_defer_openapi_rebuild,
+        )
 
 
 def deploy_pipeline_files(
@@ -612,13 +733,26 @@ def deploy_pipeline_files(
         PipelineModuleLoadError: If loading the pipeline module fails.
         PipelineWrapperError: If wrapper creation or setup fails.
     """
-    prepared = prepare_pipeline_files(pipeline_name, files=files, save_files=save_files)
-    return commit_prepared_pipeline(
-        prepared,
-        app=app,
-        overwrite=overwrite,
-        _defer_openapi_rebuild=_defer_openapi_rebuild,
-    )
+    with trace_operation(
+        SPAN_PIPELINE_DEPLOY,
+        tags=build_trace_tags(
+            {
+                "hayhooks.transport": "runtime",
+                "hayhooks.pipeline.name": pipeline_name,
+                "hayhooks.pipeline.source_type": "files",
+                "hayhooks.deploy.save_files": save_files,
+                "hayhooks.deploy.overwrite": overwrite,
+                "hayhooks.deploy.with_fastapi_route": app is not None,
+            }
+        ),
+    ):
+        prepared = prepare_pipeline_files(pipeline_name, files=files, save_files=save_files)
+        return commit_prepared_pipeline(
+            prepared,
+            app=app,
+            overwrite=overwrite,
+            _defer_openapi_rebuild=_defer_openapi_rebuild,
+        )
 
 
 def deploy_pipeline_yaml(
@@ -655,10 +789,23 @@ def deploy_pipeline_yaml(
         ValueError: If the YAML cannot be parsed into an AsyncPipeline.
         InvalidYamlIOError: If the YAML is missing inputs/outputs declarations.
     """
-    prepared = prepare_pipeline_yaml(pipeline_name, source_code=source_code, options=options)
-    return commit_prepared_pipeline(
-        prepared, app=app, overwrite=overwrite, _defer_openapi_rebuild=_defer_openapi_rebuild
-    )
+    with trace_operation(
+        SPAN_PIPELINE_DEPLOY,
+        tags=build_trace_tags(
+            {
+                "hayhooks.transport": "runtime",
+                "hayhooks.pipeline.name": pipeline_name,
+                "hayhooks.pipeline.source_type": "yaml",
+                "hayhooks.deploy.overwrite": overwrite,
+                "hayhooks.deploy.with_fastapi_route": app is not None,
+                "hayhooks.deploy.skip_mcp": (options or {}).get("skip_mcp"),
+            }
+        ),
+    ):
+        prepared = prepare_pipeline_yaml(pipeline_name, source_code=source_code, options=options)
+        return commit_prepared_pipeline(
+            prepared, app=app, overwrite=overwrite, _defer_openapi_rebuild=_defer_openapi_rebuild
+        )
 
 
 def read_pipeline_files_from_dir(dir_path: Path) -> dict[str, str]:
@@ -705,28 +852,38 @@ def undeploy_pipeline(pipeline_name: str, app: FastAPI | None = None) -> None:
     Raises:
         HTTPException: If the pipeline is not found in the registry (404).
     """
-    # Check if pipeline exists in registry
-    if pipeline_name not in registry.get_names():
-        raise HTTPException(status_code=404, detail=f"Pipeline '{pipeline_name}' not found")
+    with trace_operation(
+        SPAN_PIPELINE_UNDEPLOY,
+        tags=build_trace_tags(
+            {
+                "hayhooks.transport": "runtime",
+                "hayhooks.pipeline.name": pipeline_name,
+                "hayhooks.deploy.with_fastapi_route": app is not None,
+            }
+        ),
+    ):
+        # Check if pipeline exists in registry
+        if pipeline_name not in registry.get_names():
+            raise HTTPException(status_code=404, detail=f"Pipeline '{pipeline_name}' not found")
 
-    # Remove pipeline from registry
-    registry.remove(pipeline_name)
+        # Remove pipeline from registry
+        registry.remove(pipeline_name)
 
-    # Clean up sys.modules for wrapper-based pipelines
-    unload_pipeline_modules(pipeline_name)
+        # Clean up sys.modules for wrapper-based pipelines
+        unload_pipeline_modules(pipeline_name)
 
-    if app:
-        # Remove API routes for the pipeline
-        # All pipelines have a run endpoint at /<pipeline_name>/run
-        routes_to_remove = [
-            route for route in app.routes if isinstance(route, APIRoute) and route.path == f"/{pipeline_name}/run"
-        ]
-        for route in routes_to_remove:
-            app.routes.remove(route)
+        if app:
+            # Remove API routes for the pipeline
+            # All pipelines have a run endpoint at /<pipeline_name>/run
+            routes_to_remove = [
+                route for route in app.routes if isinstance(route, APIRoute) and route.path == f"/{pipeline_name}/run"
+            ]
+            for route in routes_to_remove:
+                app.routes.remove(route)
 
-        # Invalidate OpenAPI cache
-        app.openapi_schema = None
-        app.setup()
+            # Invalidate OpenAPI cache
+            app.openapi_schema = None
+            app.setup()
 
-    # Remove pipeline files if they exist
-    remove_pipeline_files(pipeline_name, settings.pipelines_dir)
+        # Remove pipeline files if they exist
+        remove_pipeline_files(pipeline_name, settings.pipelines_dir)

--- a/src/hayhooks/server/utils/mcp_utils.py
+++ b/src/hayhooks/server/utils/mcp_utils.py
@@ -1,9 +1,10 @@
 import json
 import traceback
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from enum import Enum
 from pathlib import Path
+from typing import Any
 
 from fastapi.concurrency import run_in_threadpool
 from haystack.lazy_imports import LazyImport
@@ -16,6 +17,15 @@ from hayhooks.server.app import init_pipeline_dir
 from hayhooks.server.logger import log
 from hayhooks.server.pipelines import registry
 from hayhooks.server.routers.deploy import PipelineFilesRequest
+from hayhooks.server.tracing import (
+    SPAN_MCP_CALL_TOOL,
+    SPAN_MCP_LIST_TOOLS,
+    SPAN_MCP_RUN_PIPELINE_TOOL,
+    build_trace_tags,
+    configure_tracing,
+    instrument_starlette_app,
+    trace_operation,
+)
 from hayhooks.server.utils.base_pipeline_wrapper import BasePipelineWrapper
 from hayhooks.server.utils.deploy_utils import (
     deploy_pipeline_files,
@@ -68,7 +78,6 @@ def deploy_pipelines() -> None:
             )
         except Exception as e:
             log.warning("Skipping pipeline directory '{}': {}", pipeline_dir, e)
-            continue
 
 
 async def list_core_tools() -> list["Tool"]:
@@ -137,106 +146,158 @@ async def list_pipelines_as_tools() -> list["Tool"]:
     return tools
 
 
-async def run_pipeline_as_tool(name: str, arguments: dict) -> list["TextContent"]:
+async def run_pipeline_as_tool(name: str, arguments: dict[str, Any]) -> list["TextContent"]:
     mcp_import.check()
 
-    log.debug("Calling pipeline as tool '{}' with arguments: {}", name, arguments)
-    pipeline_wrapper: BasePipelineWrapper | None = registry.get(name)
+    with trace_operation(
+        SPAN_MCP_RUN_PIPELINE_TOOL,
+        tags=build_trace_tags(
+            {
+                "hayhooks.transport": "mcp",
+                "hayhooks.pipeline.name": name,
+                "hayhooks.mcp.arguments.count": len(arguments),
+            }
+        ),
+    ):
+        log.debug("Calling pipeline as tool '{}' with arguments: {}", name, arguments)
+        pipeline_wrapper: BasePipelineWrapper | None = registry.get(name)
 
-    if not pipeline_wrapper:
-        msg = f"Pipeline '{name}' not found"
-        raise ValueError(msg)
+        if not pipeline_wrapper:
+            msg = f"Pipeline '{name}' not found"
+            raise ValueError(msg)
 
-    if pipeline_wrapper._is_run_api_async_implemented:
-        result = await pipeline_wrapper.run_api_async(**arguments)
-    else:
-        result = await run_in_threadpool(pipeline_wrapper.run_api, **arguments)
+        if pipeline_wrapper._is_run_api_async_implemented:
+            result = await pipeline_wrapper.run_api_async(**arguments)
+        else:
+            result = await run_in_threadpool(pipeline_wrapper.run_api, **arguments)
 
-    log.trace("Pipeline '{}' returned result: {}", name, result)
+        log.trace("Pipeline '{}' returned result: {}", name, result)
 
-    # Format result: if it's a dict (from YAML pipeline), convert to JSON string
-    if isinstance(result, dict):
-        return [TextContent(text=json.dumps(result), type="text")]
-    return [TextContent(text=str(result), type="text")]
+        # Format result: if it's a dict (from YAML pipeline), convert to JSON string
+        if isinstance(result, dict):
+            return [TextContent(text=json.dumps(result), type="text")]
+        return [TextContent(text=str(result), type="text")]
 
 
 async def notify_client(server: "Server") -> None:
     await server.request_context.session.send_tool_list_changed()
 
 
-def create_mcp_server(name: str = "hayhooks-mcp-server") -> "Server":  # noqa: C901
+async def _handle_deploy_pipeline(arguments: dict[str, Any], span: Any) -> list["TextContent"]:
+    span.set_tag("hayhooks.pipeline.name", arguments.get("name"))
+    result = await deploy_pipeline_files_async(
+        pipeline_name=arguments["name"],
+        files=arguments["files"],
+        app=None,
+        save_files=arguments["save_files"],
+        overwrite=arguments["overwrite"],
+    )
+    return [TextContent(type="text", text=f"Pipeline '{result['name']}' deployed successfully")]
+
+
+async def _handle_get_all_pipeline_statuses(_arguments: dict[str, Any], _span: Any) -> list["TextContent"]:
+    pipelines_str = "\n".join(registry.get_names())
+    return [TextContent(type="text", text=f"Available pipelines:\n{pipelines_str}")]
+
+
+async def _handle_get_pipeline_status(arguments: dict[str, Any], span: Any) -> list["TextContent"]:
+    pipeline_name = arguments["pipeline_name"]
+    span.set_tag("hayhooks.pipeline.name", pipeline_name)
+    is_deployed = pipeline_name in registry.get_names()
+    return [TextContent(type="text", text=f"Pipeline '{pipeline_name}' is deployed: {is_deployed}")]
+
+
+async def _handle_undeploy_pipeline(arguments: dict[str, Any], span: Any) -> list["TextContent"]:
+    pipeline_name = arguments["pipeline_name"]
+    span.set_tag("hayhooks.pipeline.name", pipeline_name)
+    # app=None: the MCP server doesn't own FastAPI routes
+    await undeploy_pipeline_async(pipeline_name=pipeline_name)
+    return [TextContent(type="text", text=f"Pipeline '{pipeline_name}' undeployed")]
+
+
+# Core tools that trigger a ``tools/list_changed`` notification after execution.
+_MUTATING_CORE_TOOLS: frozenset[str] = frozenset({CoreTools.DEPLOY_PIPELINE.value, CoreTools.UNDEPLOY_PIPELINE.value})
+
+_CoreToolHandler = Callable[[dict[str, Any], Any], Awaitable[list["TextContent"]]]
+
+_CORE_TOOL_HANDLERS: dict[str, _CoreToolHandler] = {
+    CoreTools.DEPLOY_PIPELINE.value: _handle_deploy_pipeline,
+    CoreTools.GET_ALL_PIPELINE_STATUSES.value: _handle_get_all_pipeline_statuses,
+    CoreTools.GET_PIPELINE_STATUS.value: _handle_get_pipeline_status,
+    CoreTools.UNDEPLOY_PIPELINE.value: _handle_undeploy_pipeline,
+}
+
+
+async def _run_pipeline_tool(name: str, arguments: dict[str, Any], span: Any) -> list["TextContent"]:
+    log.debug("Attempting to run pipeline '{}' as MCP Tool with arguments: {}", name, arguments)
+    span.set_tag("hayhooks.pipeline.name", name)
+
+    try:
+        return await run_pipeline_as_tool(name, arguments)
+    except Exception as exc:
+        msg = f"Error calling pipeline as MCP Tool '{name}': {exc}"
+        log.opt(exception=True).error(msg)
+        raise Exception(msg) from exc
+
+
+def create_mcp_server(name: str = "hayhooks-mcp-server") -> "Server":
     mcp_import.check()
 
     server: Server = Server(name)
 
     @server.list_tools()
     async def list_tools() -> list[Tool]:
-        try:
-            core_tools = await list_core_tools()
-            log.debug("Listing {} core tools", len(core_tools))
+        with trace_operation(
+            SPAN_MCP_LIST_TOOLS,
+            tags=build_trace_tags(
+                {
+                    "hayhooks.transport": "mcp",
+                    "hayhooks.action": "list_tools",
+                }
+            ),
+        ):
+            try:
+                core_tools = await list_core_tools()
+                log.debug("Listing {} core tools", len(core_tools))
 
-            pipelines_tools = await list_pipelines_as_tools()
-            log.debug("Listing {} pipelines as tools", len(pipelines_tools))
+                pipelines_tools = await list_pipelines_as_tools()
+                log.debug("Listing {} pipelines as tools", len(pipelines_tools))
 
-            return core_tools + pipelines_tools
-        except Exception as e:
-            log.error("Error listing tools: {}", e)
-            return []
+                return core_tools + pipelines_tools
+            except Exception as e:
+                log.error("Error listing tools: {}", e)
+                return []
 
     @server.call_tool()
-    async def call_tool(name: str, arguments: dict) -> list["TextContent"]:
-        try:
-            if name == CoreTools.DEPLOY_PIPELINE:
-                result = await deploy_pipeline_files_async(
-                    pipeline_name=arguments["name"],
-                    files=arguments["files"],
-                    app=None,
-                    save_files=arguments["save_files"],
-                    overwrite=arguments["overwrite"],
-                )
-                return [TextContent(type="text", text=f"Pipeline '{result['name']}' deployed successfully")]
+    async def call_tool(name: str, arguments: dict[str, Any]) -> list["TextContent"]:
+        handler = _CORE_TOOL_HANDLERS.get(name)
+        is_core_tool = handler is not None
 
-            elif name == CoreTools.GET_ALL_PIPELINE_STATUSES:
-                pipelines = registry.get_names()
-                pipelines_str = "\n".join(pipelines)
-                return [TextContent(type="text", text=f"Available pipelines:\n{pipelines_str}")]
-
-            elif name == CoreTools.GET_PIPELINE_STATUS:
-                pipeline_name = arguments["pipeline_name"]
-                is_deployed = pipeline_name in registry.get_names()
-                return [TextContent(type="text", text=f"Pipeline '{pipeline_name}' is deployed: {is_deployed}")]
-
-            elif name == CoreTools.UNDEPLOY_PIPELINE:
-                pipeline_name = arguments["pipeline_name"]
-                # app=None: the MCP server doesn't own FastAPI routes
-                await undeploy_pipeline_async(pipeline_name=pipeline_name)
-                return [TextContent(type="text", text=f"Pipeline '{pipeline_name}' undeployed")]
-
-            else:
-                log.debug(
-                    "Attempting to run pipeline '{}' as MCP Tool with arguments: {}",
-                    name,
-                    arguments,
-                )
-
-                try:
-                    return await run_pipeline_as_tool(name, arguments)
-                except Exception as e_pipeline:
-                    msg = "Error calling pipeline as MCP Tool '{name}': {e_pipeline}"
-                    log.opt(exception=True).error(msg, name=name, e_pipeline=e_pipeline)
-                    raise Exception(msg.format(name=name, e_pipeline=e_pipeline)) from e_pipeline
-
-        except Exception as exc:
-            msg = "General unhandled error in call_tool for tool '{name}': {exc}"
-            if settings.show_tracebacks:
-                msg += f"\n{traceback.format_exc()}"
-            log.opt(exception=True).error(msg, name=name, exc=exc)
-            raise Exception(msg.format(name=name, exc=exc)) from exc
-
-        finally:
-            if name in [CoreTools.DEPLOY_PIPELINE, CoreTools.UNDEPLOY_PIPELINE]:
-                log.debug("Sending 'tools/list_changed' notification after deploy/undeploy")
-                await notify_client(server)
+        with trace_operation(
+            SPAN_MCP_CALL_TOOL,
+            tags=build_trace_tags(
+                {
+                    "hayhooks.transport": "mcp",
+                    "hayhooks.tool.name": name,
+                    "hayhooks.tool.is_core": is_core_tool,
+                    "hayhooks.action": name if is_core_tool else "run_pipeline_tool",
+                }
+            ),
+        ) as span:
+            try:
+                if handler is not None:
+                    return await handler(arguments, span)
+                return await _run_pipeline_tool(name, arguments, span)
+            except Exception as exc:
+                msg = f"General unhandled error in call_tool for tool '{name}': {exc}"
+                if settings.show_tracebacks:
+                    msg += f"\n{traceback.format_exc()}"
+                log.opt(exception=True).error(msg)
+                raise Exception(msg) from exc
+            finally:
+                if name in _MUTATING_CORE_TOOLS:
+                    log.debug("Sending 'tools/list_changed' notification after deploy/undeploy")
+                    await notify_client(server)
 
     return server
 
@@ -277,7 +338,7 @@ def create_starlette_app(server: "Server", *, debug: bool = False, json_response
     async def handle_status(request):  # noqa: ARG001
         return JSONResponse({"status": "ok"})
 
-    return Starlette(
+    app = Starlette(
         debug=debug,
         routes=[
             Route("/sse", endpoint=handle_sse),
@@ -287,3 +348,7 @@ def create_starlette_app(server: "Server", *, debug: bool = False, json_response
         ],
         lifespan=lifespan,
     )
+
+    configure_tracing()
+    instrument_starlette_app(app)
+    return app

--- a/src/hayhooks/settings.py
+++ b/src/hayhooks/settings.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from pathlib import Path
+from typing import Literal
 
 from dotenv import find_dotenv, load_dotenv
 from pydantic import Field
@@ -99,6 +100,10 @@ class AppSettings(BaseSettings):
     # Only these loggers are patched; everything else (httpx, haystack, etc.)
     # keeps its default behaviour.
     intercepted_loggers: list[str] = ["uvicorn", "uvicorn.error", "uvicorn.access", "fastapi"]
+
+    # Exclude low-level ASGI send/receive spans from framework instrumentation
+    # to keep streaming traces readable by default.
+    tracing_excluded_spans: list[Literal["send", "receive"]] = ["send", "receive"]
 
     # Chainlit Settings
     # Enable embedded Chainlit UI frontend

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,91 @@
 import shutil
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path
+from typing import Any
 
 import pytest
 from _pytest.logging import LogCaptureFixture
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from haystack.tracing import Span, Tracer, disable_tracing, enable_tracing
 
 from hayhooks.server.app import create_app
 from hayhooks.server.logger import log
 from hayhooks.server.pipelines.registry import registry
 from hayhooks.server.utils.mcp_utils import create_mcp_server, create_starlette_app
 from hayhooks.settings import settings
+
+
+class _RecordedSpan(Span):
+    def __init__(
+        self, operation_name: str, tags: dict[str, Any], trace_id: int, span_id: int, parent_span_id: int | None
+    ):
+        self.operation_name = operation_name
+        self.tags = tags
+        self.trace_id = trace_id
+        self.span_id = span_id
+        self.parent_span_id = parent_span_id
+
+    def set_tag(self, key: str, value: Any) -> None:
+        self.tags[key] = value
+
+    def get_correlation_data_for_logs(self) -> dict[str, Any]:
+        return {"trace_id": self.trace_id, "span_id": self.span_id}
+
+
+class _RecordingTracer(Tracer):
+    def __init__(self) -> None:
+        self.spans: list[_RecordedSpan] = []
+        self._active_spans: ContextVar[tuple[_RecordedSpan, ...]] = ContextVar("_recording_tracer_active_spans", default=())
+        self._next_id = 1
+
+    @contextmanager
+    def trace(
+        self,
+        operation_name: str,
+        tags: dict[str, Any] | None = None,
+        parent_span: Span | None = None,
+    ) -> Iterator[Span]:
+        active_spans = self._active_spans.get()
+        parent = parent_span if isinstance(parent_span, _RecordedSpan) else (active_spans[-1] if active_spans else None)
+        trace_id = parent.trace_id if isinstance(parent, _RecordedSpan) else self._allocate_id()
+        span_id = self._allocate_id()
+        span = _RecordedSpan(
+            operation_name=operation_name,
+            tags=dict(tags or {}),
+            trace_id=trace_id,
+            span_id=span_id,
+            parent_span_id=parent.span_id if isinstance(parent, _RecordedSpan) else None,
+        )
+        self.spans.append(span)
+        token = self._active_spans.set((*active_spans, span))
+        try:
+            yield span
+        finally:
+            self._active_spans.reset(token)
+
+    def current_span(self) -> Span | None:
+        active_spans = self._active_spans.get()
+        if active_spans:
+            return active_spans[-1]
+        return None
+
+    def _allocate_id(self) -> int:
+        current = self._next_id
+        self._next_id += 1
+        return current
+
+
+@pytest.fixture
+def recording_tracer() -> Iterator[_RecordingTracer]:
+    tracer = _RecordingTracer()
+    enable_tracing(tracer)
+    try:
+        yield tracer
+    finally:
+        disable_tracing()
 
 
 @pytest.fixture

--- a/tests/test_it_mcp_server.py
+++ b/tests/test_it_mcp_server.py
@@ -5,6 +5,7 @@ import pytest
 from anyio import Path
 
 from hayhooks.server.pipelines import registry
+from hayhooks.server.tracing import SPAN_MCP_CALL_TOOL
 from hayhooks.server.utils.deploy_utils import deploy_pipeline_files, deploy_pipeline_yaml
 from hayhooks.server.utils.mcp_utils import CoreTools, create_mcp_server
 
@@ -114,6 +115,18 @@ async def test_call_pipeline_as_tool(mcp_server_instance, deploy_chat_with_websi
 
         # In the deployed pipeline, the response is mocked
         assert result.content == [TextContent(type="text", text="This is a mock response from the pipeline")]
+
+
+@pytest.mark.asyncio
+async def test_call_tool_emits_trace_span(mcp_server_instance, recording_tracer):
+    async with client_session(mcp_server_instance) as client:
+        result = await client.call_tool(CoreTools.GET_ALL_PIPELINE_STATUSES, {})
+        assert isinstance(result, CallToolResult)
+
+    spans = [span for span in recording_tracer.spans if span.operation_name == SPAN_MCP_CALL_TOOL]
+    assert spans
+    assert spans[-1].tags["hayhooks.tool.name"] == CoreTools.GET_ALL_PIPELINE_STATUSES
+    assert spans[-1].tags["hayhooks.transport"] == "mcp"
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -5,6 +5,7 @@ from anyio import Path
 
 from hayhooks.server.pipelines import registry
 from hayhooks.server.routers.deploy import PipelineFilesRequest
+from hayhooks.server.tracing import SPAN_MCP_RUN_PIPELINE_TOOL
 from hayhooks.server.utils.deploy_utils import deploy_pipeline_files
 from hayhooks.server.utils.mcp_utils import (
     PIPELINE_NAME_SCHEMA,
@@ -108,6 +109,16 @@ async def test_run_pipeline_as_tool_returns_text_content(deploy_chat_with_websit
     assert len(result) == 1
     assert isinstance(result[0], TextContent)
     assert result[0].text == "This is a mock response from the pipeline"
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_as_tool_emits_trace_span(deploy_chat_with_website_mcp, recording_tracer):
+    await run_pipeline_as_tool("chat_with_website", {"urls": ["https://www.google.com"], "question": "Trace this"})
+
+    spans = [span for span in recording_tracer.spans if span.operation_name == SPAN_MCP_RUN_PIPELINE_TOOL]
+    assert spans
+    assert spans[-1].tags["hayhooks.pipeline.name"] == "chat_with_website"
+    assert spans[-1].tags["hayhooks.transport"] == "mcp"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,450 @@
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.applications import Starlette
+
+from hayhooks.server.app import create_app
+from hayhooks.server.logger import normalize_trace_correlation_data
+from hayhooks.server.pipelines.registry import registry
+from hayhooks.server.tracing import (
+    SPAN_OPENAI_RUN,
+    SPAN_PIPELINE_DEPLOY,
+    SPAN_PIPELINE_DEPLOY_COMMIT,
+    SPAN_PIPELINE_DEPLOY_PREPARE,
+    SPAN_PIPELINE_RUN,
+    SPAN_PIPELINE_STARTUP_DEPLOY,
+    SPAN_PIPELINE_UNDEPLOY,
+    _OTLP_HTTP_PROTOBUF,
+    _build_otlp_span_exporter,
+    _normalize_otlp_protocol,
+    configure_tracing,
+    instrument_fastapi_app,
+    instrument_starlette_app,
+)
+from hayhooks.server.utils.deploy_utils import deploy_pipeline_yaml, undeploy_pipeline
+from hayhooks.settings import StartupDeployStrategy, settings
+
+SAMPLE_YAML = (Path(__file__).parent / "test_files/yaml/sample_calc_pipeline.yml").read_text()
+
+CHAT_PIPELINE_DIR = Path(__file__).parent / "test_files/files/chat_with_website"
+CHAT_PIPELINE_FILES = {
+    "pipeline_wrapper.py": (CHAT_PIPELINE_DIR / "pipeline_wrapper.py").read_text(),
+    "chat_with_website.yml": (CHAT_PIPELINE_DIR / "chat_with_website.yml").read_text(),
+}
+
+CHAT_STREAMING_PIPELINE_DIR = Path(__file__).parent / "test_files/files/chat_with_website_streaming"
+CHAT_STREAMING_PIPELINE_FILES = {
+    "pipeline_wrapper.py": (CHAT_STREAMING_PIPELINE_DIR / "pipeline_wrapper.py").read_text(),
+    "chat_with_website.yml": (CHAT_STREAMING_PIPELINE_DIR / "chat_with_website.yml").read_text(),
+}
+
+RUN_API_STREAMING_PIPELINE_DIR = Path(__file__).parent / "test_files/files/run_api_streaming"
+RUN_API_STREAMING_PIPELINE_FILES = {
+    "pipeline_wrapper.py": (RUN_API_STREAMING_PIPELINE_DIR / "pipeline_wrapper.py").read_text(),
+}
+
+BROKEN_STREAMING_PIPELINE_FILES = {
+    "pipeline_wrapper.py": """
+from collections.abc import Generator
+
+from haystack.dataclasses import StreamingChunk
+
+from hayhooks import BasePipelineWrapper
+
+
+class PipelineWrapper(BasePipelineWrapper):
+    def setup(self) -> None:
+        self.pipeline = None
+
+    def run_api(self, query: str) -> Generator[StreamingChunk, None, None]:
+        def stream() -> Generator[StreamingChunk, None, None]:
+            yield StreamingChunk(content=f"{query} ")
+            raise RuntimeError("run_api stream exploded")
+
+        return stream()
+
+    def run_chat_completion(
+        self, model: str, messages: list[dict], body: dict
+    ) -> Generator[StreamingChunk, None, None]:
+        def stream() -> Generator[StreamingChunk, None, None]:
+            yield StreamingChunk(content="first ")
+            raise RuntimeError("chat stream exploded")
+
+        return stream()
+""",
+}
+
+
+def test_normalize_trace_correlation_data_formats_identifiers():
+    normalized = normalize_trace_correlation_data({"trace_id": 10, "span_id": 11, "custom": "value"})
+    assert normalized == {
+        "trace_id": "0000000000000000000000000000000a",
+        "span_id": "000000000000000b",
+        "custom": "value",
+    }
+
+
+def test_instrument_fastapi_app_is_idempotent(monkeypatch):
+    class FakeFastAPIInstrumentor:
+        calls = 0
+
+        @classmethod
+        def instrument_app(cls, app):  # noqa: ARG003
+            cls.calls += 1
+
+    monkeypatch.setattr("hayhooks.server.tracing._load_fastapi_instrumentor", lambda: FakeFastAPIInstrumentor)
+
+    app = FastAPI()
+    assert instrument_fastapi_app(app) is True
+    assert instrument_fastapi_app(app) is True
+    assert FakeFastAPIInstrumentor.calls == 1
+
+
+def test_instrument_fastapi_app_passes_excluded_spans(monkeypatch):
+    recorded: dict[str, object] = {}
+
+    class FakeFastAPIInstrumentor:
+        @classmethod
+        def instrument_app(cls, app, **kwargs):  # noqa: ARG003
+            recorded["kwargs"] = kwargs
+
+    monkeypatch.setattr("hayhooks.server.tracing._load_fastapi_instrumentor", lambda: FakeFastAPIInstrumentor)
+    monkeypatch.setattr(settings, "tracing_excluded_spans", ["send"])
+
+    app = FastAPI()
+    assert instrument_fastapi_app(app) is True
+    assert recorded["kwargs"] == {"exclude_spans": ["send"]}
+
+
+def test_instrument_starlette_app_noop_when_dependency_missing(monkeypatch):
+    monkeypatch.setattr("hayhooks.server.tracing._load_starlette_instrumentor", lambda: None)
+    app = Starlette()
+    assert instrument_starlette_app(app) is False
+
+
+def test_instrument_starlette_app_passes_excluded_spans(monkeypatch):
+    recorded: dict[str, object] = {}
+
+    class FakeStarletteInstrumentor:
+        @classmethod
+        def instrument_app(cls, app, **kwargs):  # noqa: ARG003
+            recorded["kwargs"] = kwargs
+
+    monkeypatch.setattr("hayhooks.server.tracing._load_starlette_instrumentor", lambda: FakeStarletteInstrumentor)
+    monkeypatch.setattr(settings, "tracing_excluded_spans", ["send", "receive"])
+
+    app = Starlette()
+    assert instrument_starlette_app(app) is True
+    assert recorded["kwargs"] == {"exclude_spans": ["send", "receive"]}
+
+
+def test_normalize_otlp_protocol():
+    assert _normalize_otlp_protocol(None) == "http/protobuf"
+    assert _normalize_otlp_protocol("http") == "http/protobuf"
+    assert _normalize_otlp_protocol("http/protobuf") == "http/protobuf"
+    assert _normalize_otlp_protocol("grpc") == "grpc"
+    assert _normalize_otlp_protocol("unsupported") is None
+
+
+def test_build_otlp_http_exporter_uses_env_endpoint_resolution(monkeypatch):
+    class _FakeLazyImport:
+        @staticmethod
+        def check() -> None:
+            return None
+
+    class _FakeExporter:
+        kwargs: dict = {}
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    monkeypatch.setattr("hayhooks.server.tracing.otlp_http_exporter_import", _FakeLazyImport())
+    monkeypatch.setattr("hayhooks.server.tracing.OTLPHTTPSpanExporter", _FakeExporter, raising=False)
+
+    exporter = _build_otlp_span_exporter(_OTLP_HTTP_PROTOBUF)
+
+    assert isinstance(exporter, _FakeExporter)
+    assert exporter.kwargs == {}
+
+
+def test_configure_tracing_noop_when_already_enabled(monkeypatch):
+    calls = {"auto": 0, "bootstrap": 0}
+    monkeypatch.setattr("hayhooks.server.tracing.is_tracing_enabled", lambda: True)
+
+    def fake_auto_enable():
+        calls["auto"] += 1
+
+    def fake_bootstrap():
+        calls["bootstrap"] += 1
+        return True
+
+    monkeypatch.setattr("hayhooks.server.tracing.auto_enable_tracing", fake_auto_enable)
+    monkeypatch.setattr("hayhooks.server.tracing._configure_otel_tracer_from_env", fake_bootstrap)
+
+    assert configure_tracing() is True
+    assert calls == {"auto": 0, "bootstrap": 0}
+
+
+def test_configure_tracing_uses_haystack_auto_enable(monkeypatch):
+    state = {"enabled": False}
+    calls = {"bootstrap": 0}
+
+    def fake_is_tracing_enabled():
+        return state["enabled"]
+
+    def fake_auto_enable():
+        state["enabled"] = True
+
+    def fake_bootstrap():
+        calls["bootstrap"] += 1
+        return True
+
+    monkeypatch.setattr("hayhooks.server.tracing.is_tracing_enabled", fake_is_tracing_enabled)
+    monkeypatch.setattr("hayhooks.server.tracing.auto_enable_tracing", fake_auto_enable)
+    monkeypatch.setattr("hayhooks.server.tracing._configure_otel_tracer_from_env", fake_bootstrap)
+
+    assert configure_tracing() is True
+    assert calls["bootstrap"] == 0
+
+
+def test_configure_tracing_falls_back_to_otlp_bootstrap(monkeypatch):
+    calls = {"auto": 0, "bootstrap": 0}
+
+    monkeypatch.setattr("hayhooks.server.tracing.is_tracing_enabled", lambda: False)
+
+    def fake_auto_enable():
+        calls["auto"] += 1
+
+    def fake_bootstrap():
+        calls["bootstrap"] += 1
+        return True
+
+    monkeypatch.setattr("hayhooks.server.tracing.auto_enable_tracing", fake_auto_enable)
+    monkeypatch.setattr("hayhooks.server.tracing._configure_otel_tracer_from_env", fake_bootstrap)
+
+    assert configure_tracing() is True
+    assert calls == {"auto": 1, "bootstrap": 1}
+
+
+def test_deploy_and_undeploy_emit_lifecycle_spans(recording_tracer):
+    registry.clear()
+
+    deploy_pipeline_yaml(
+        pipeline_name="trace_lifecycle_pipeline",
+        source_code=SAMPLE_YAML,
+        options={"save_file": False},
+    )
+    undeploy_pipeline("trace_lifecycle_pipeline")
+
+    span_names = [span.operation_name for span in recording_tracer.spans]
+
+    assert SPAN_PIPELINE_DEPLOY in span_names
+    assert SPAN_PIPELINE_DEPLOY_PREPARE in span_names
+    assert SPAN_PIPELINE_DEPLOY_COMMIT in span_names
+    assert SPAN_PIPELINE_UNDEPLOY in span_names
+
+
+def test_run_endpoint_emits_pipeline_run_span(client, deploy_yaml_pipeline, recording_tracer):
+    registry.clear()
+    pipeline_name = "trace_run_pipeline"
+
+    deploy_response = deploy_yaml_pipeline(client, pipeline_name, SAMPLE_YAML)
+    assert deploy_response.status_code == 200
+
+    run_response = client.post(f"/{pipeline_name}/run", json={"value": 3})
+    assert run_response.status_code == 200
+
+    run_spans = [span for span in recording_tracer.spans if span.operation_name == SPAN_PIPELINE_RUN]
+    assert run_spans
+    assert any(span.tags.get("hayhooks.pipeline.name") == pipeline_name for span in run_spans)
+
+    client.post(f"/undeploy/{pipeline_name}")
+
+
+def test_openai_chat_completion_emits_openai_run_span(client, deploy_files, recording_tracer):
+    registry.clear()
+    pipeline_name = "trace_openai_pipeline"
+
+    deploy_response = deploy_files(client, pipeline_name, CHAT_PIPELINE_FILES)
+    assert deploy_response.status_code == 200
+
+    response = client.post(
+        "/chat/completions",
+        json={
+            "model": pipeline_name,
+            "messages": [{"role": "user", "content": "What is Redis?"}],
+            "stream": False,
+        },
+    )
+    assert response.status_code == 200
+
+    openai_spans = [span for span in recording_tracer.spans if span.operation_name == SPAN_OPENAI_RUN]
+    assert openai_spans
+    assert any(
+        span.tags.get("hayhooks.pipeline.name") == pipeline_name
+        and span.tags.get("hayhooks.openai.operation") == "run_chat_completion"
+        for span in openai_spans
+    )
+
+    client.post(f"/undeploy/{pipeline_name}")
+
+
+def test_run_endpoint_streaming_span_tags_reflect_actual_streaming(
+    client, deploy_yaml_pipeline, deploy_files, recording_tracer
+):
+    registry.clear()
+
+    non_streaming_pipeline = "trace_run_non_streaming"
+    streaming_pipeline = "trace_run_streaming"
+
+    assert deploy_yaml_pipeline(client, non_streaming_pipeline, SAMPLE_YAML).status_code == 200
+    assert deploy_files(client, streaming_pipeline, RUN_API_STREAMING_PIPELINE_FILES).status_code == 200
+
+    non_streaming_response = client.post(f"/{non_streaming_pipeline}/run", json={"value": 3})
+    assert non_streaming_response.status_code == 200
+
+    with client.stream("POST", f"/{streaming_pipeline}/run", json={"query": "stream me"}) as stream_response:
+        assert stream_response.status_code == 200
+        list(stream_response.iter_text())
+
+    run_spans = [span for span in recording_tracer.spans if span.operation_name == SPAN_PIPELINE_RUN]
+    assert len(run_spans) >= 2
+
+    non_streaming_span = next(span for span in run_spans if span.tags.get("hayhooks.pipeline.name") == non_streaming_pipeline)
+    streaming_span = next(span for span in run_spans if span.tags.get("hayhooks.pipeline.name") == streaming_pipeline)
+
+    assert "hayhooks.response.streaming" not in non_streaming_span.tags
+    assert "hayhooks.response.stream_type" not in non_streaming_span.tags
+    assert streaming_span.tags["hayhooks.response.streaming"] is True
+    assert streaming_span.tags["hayhooks.response.stream_type"] == "plain"
+
+
+def test_openai_streaming_span_tags_reflect_actual_streaming(client, deploy_files, recording_tracer):
+    registry.clear()
+
+    non_streaming_pipeline = "trace_openai_non_streaming"
+    streaming_pipeline = "trace_openai_streaming"
+
+    assert deploy_files(client, non_streaming_pipeline, CHAT_PIPELINE_FILES).status_code == 200
+    assert deploy_files(client, streaming_pipeline, CHAT_STREAMING_PIPELINE_FILES).status_code == 200
+
+    non_streaming_response = client.post(
+        "/chat/completions",
+        json={
+            "model": non_streaming_pipeline,
+            "messages": [{"role": "user", "content": "What is Redis?"}],
+            "stream": False,
+        },
+    )
+    assert non_streaming_response.status_code == 200
+
+    with client.stream(
+        "POST",
+        "/chat/completions",
+        json={
+            "model": streaming_pipeline,
+            "messages": [{"role": "user", "content": "What is Redis?"}],
+            "stream": True,
+        },
+    ) as stream_response:
+        assert stream_response.status_code == 200
+        list(stream_response.iter_lines())
+
+    openai_spans = [span for span in recording_tracer.spans if span.operation_name == SPAN_OPENAI_RUN]
+    assert len(openai_spans) >= 2
+
+    non_streaming_span = next(
+        span for span in openai_spans if span.tags.get("hayhooks.pipeline.name") == non_streaming_pipeline
+    )
+    streaming_span = next(span for span in openai_spans if span.tags.get("hayhooks.pipeline.name") == streaming_pipeline)
+
+    assert "hayhooks.response.streaming" not in non_streaming_span.tags
+    assert "hayhooks.response.stream_type" not in non_streaming_span.tags
+    assert streaming_span.tags["hayhooks.response.streaming"] is True
+    assert streaming_span.tags["hayhooks.response.stream_type"] == "sse"
+
+
+def test_run_endpoint_streaming_error_marks_span_failure(client, deploy_files, recording_tracer):
+    registry.clear()
+    pipeline_name = "trace_run_streaming_failure"
+
+    deploy_response = deploy_files(client, pipeline_name, BROKEN_STREAMING_PIPELINE_FILES)
+    assert deploy_response.status_code == 200
+
+    with pytest.raises(RuntimeError, match="run_api stream exploded"):
+        with client.stream("POST", f"/{pipeline_name}/run", json={"query": "stream"}) as stream_response:
+            assert stream_response.status_code == 200
+            list(stream_response.iter_text())
+
+    run_spans = [span for span in recording_tracer.spans if span.operation_name == SPAN_PIPELINE_RUN]
+    assert run_spans
+    assert run_spans[-1].tags["hayhooks.success"] is False
+    assert run_spans[-1].tags["hayhooks.error.type"] == "RuntimeError"
+
+
+def test_openai_streaming_error_marks_span_failure(client, deploy_files, recording_tracer):
+    registry.clear()
+    pipeline_name = "trace_openai_streaming_failure"
+
+    deploy_response = deploy_files(client, pipeline_name, BROKEN_STREAMING_PIPELINE_FILES)
+    assert deploy_response.status_code == 200
+
+    with pytest.raises(RuntimeError, match="chat stream exploded"):
+        with client.stream(
+            "POST",
+            "/chat/completions",
+            json={
+                "model": pipeline_name,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+            },
+        ) as stream_response:
+            assert stream_response.status_code == 200
+            list(stream_response.iter_lines())
+
+    openai_spans = [span for span in recording_tracer.spans if span.operation_name == SPAN_OPENAI_RUN]
+    assert openai_spans
+    assert openai_spans[-1].tags["hayhooks.success"] is False
+    assert openai_spans[-1].tags["hayhooks.error.type"] == "RuntimeError"
+
+
+def test_openai_http_4xx_marks_span_failure(client, recording_tracer):
+    response = client.post(
+        "/chat/completions",
+        json={
+            "model": "non_existent_pipeline",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": False,
+        },
+    )
+    assert response.status_code == 404
+
+    openai_spans = [span for span in recording_tracer.spans if span.operation_name == SPAN_OPENAI_RUN]
+    assert openai_spans
+    assert openai_spans[-1].tags["hayhooks.success"] is False
+    assert openai_spans[-1].tags["hayhooks.http.status_code"] == 404
+
+
+def test_parallel_startup_prepare_spans_keep_startup_parent(monkeypatch, recording_tracer, tmp_path):
+    registry.clear()
+
+    (tmp_path / "startup_one.yml").write_text(SAMPLE_YAML)
+    (tmp_path / "startup_two.yml").write_text(SAMPLE_YAML)
+
+    monkeypatch.setattr(settings, "pipelines_dir", str(tmp_path))
+    monkeypatch.setattr(settings, "startup_deploy_strategy", StartupDeployStrategy.PARALLEL)
+    monkeypatch.setattr(settings, "startup_deploy_workers", 2)
+
+    app = create_app()
+    with TestClient(app) as client:
+        response = client.get("/status")
+        assert response.status_code == 200
+
+    startup_spans = [span for span in recording_tracer.spans if span.operation_name == SPAN_PIPELINE_STARTUP_DEPLOY]
+    prepare_spans = [span for span in recording_tracer.spans if span.operation_name == SPAN_PIPELINE_DEPLOY_PREPARE]
+
+    assert len(startup_spans) == 1
+    assert len(prepare_spans) == 2
+    assert all(span.parent_span_id == startup_spans[0].span_id for span in prepare_spans)


### PR DESCRIPTION
This PR adds optional tracing support via `hayhooks[tracing]` and introduces centralized tracing helpers in `src/hayhooks/server/tracing.py` (OTLP bootstrap, framework instrumentation, operation/span utilities).

- Instruments core flows with domain spans and consistent tags across startup, deploy/run/undeploy, OpenAI-compatible endpoints, and MCP tools (`src/hayhooks/server/app.py`, `src/hayhooks/server/utils/deploy_utils.py`, `src/hayhooks/server/routers/openai.py`, `src/hayhooks/server/utils/mcp_utils.py`).
- Improves tracing semantics: stream spans stay open for full stream lifetime, HTTP exceptions mark domain spans as failures, and streaming tags are only set on real streaming responses.
- Adds `HAYHOOKS_TRACING_EXCLUDED_SPANS` (default `["send", "receive"]`) to reduce noisy ASGI spans and normalizes `trace_id`/`span_id` log correlation formatting in `src/hayhooks/server/logger.py`.
- Expands docs (`README.md`, install/env/logging/MCP docs) and test coverage (`tests/test_tracing.py`, `tests/test_mcp.py`, `tests/test_it_mcp_server.py`, `tests/conftest.py`) for tracing behavior and edge cases.

<img width="1652" height="952" alt="Screenshot 2026-04-21 at 14 40 31" src="https://github.com/user-attachments/assets/1ccf06ac-7bae-4898-9f33-59ef1a80dea1" />

<img width="1706" height="1180" alt="Screenshot 2026-04-21 at 14 40 55" src="https://github.com/user-attachments/assets/a7027e9a-3a02-46c5-83f1-807e942ea040" />

So it will be possible to see both Hayhooks and Haystack traces together - Hayhooks specific traces contains info about streaming/non-streaming, run method, pipeline name and so on.

Quick start for tracing is in a dedicated [tracing.md](https://github.com/deepset-ai/hayhooks/blob/tracing/docs/reference/tracing.md) docs section.