### PR TITLE
Fix: async callback passed to sync Pipeline → ValueError

### DIFF
--- a/src/hayhooks/server/pipelines/streaming.py
+++ b/src/hayhooks/server/pipelines/streaming.py
@@ -542,7 +542,12 @@ def streaming_generator(  # noqa: PLR0913
 
 
 def _create_hybrid_streaming_callback(
-    queue: asyncio.Queue[StreamingChunk], component: Component, component_name: str, loop: asyncio.AbstractEventLoop
+    queue: asyncio.Queue[StreamingChunk],
+    component: Component,
+    component_name: str,
+    loop: asyncio.AbstractEventLoop,
+    *,
+    force_sync_callbacks: bool = False,
 ) -> Callable:
     """
     Creates a streaming callback (sync or async) based on component capabilities.
@@ -550,18 +555,22 @@ def _create_hybrid_streaming_callback(
     For components without run_async (sync-only), wraps the sync callback to work with asyncio.
     For components with run_async (async-capable), returns an async callback.
 
+    When ``force_sync_callbacks`` is True, always returns a sync callback that bridges to the
+    async queue via ``asyncio.run_coroutine_threadsafe``, regardless of component capabilities.
+
     Args:
         queue: The asyncio queue to put chunks into
         component: The component to check for async support
         component_name: Name of the component (for logging)
         loop: The event loop to use for thread-safe operations
+        force_sync_callbacks: When True, always create a sync callback
 
     Returns:
         A streaming callback function (sync or async) appropriate for the component
     """
     has_async_support = hasattr(component, "run_async")
 
-    if has_async_support:
+    if has_async_support and not force_sync_callbacks:
 
         async def async_callback(chunk: StreamingChunk) -> None:
             await queue.put(chunk)
@@ -634,12 +643,14 @@ def _validate_async_streaming_support(
     return (False, streaming_components)
 
 
-def _setup_hybrid_streaming_callbacks_for_pipeline(
+def _setup_hybrid_streaming_callbacks_for_pipeline(  # noqa: PLR0913
     pipeline_run_args: dict[str, Any],
     queue: asyncio.Queue[StreamingChunk],
     loop: asyncio.AbstractEventLoop,
     all_streaming_components: list[tuple[Component, str]],
     streaming_components: list[str] | Literal["all"] | None = None,
+    *,
+    force_sync_callbacks: bool = False,
 ) -> dict[str, Any]:
     """
     Sets up hybrid streaming callbacks (sync or async) for pipeline components.
@@ -648,12 +659,18 @@ def _setup_hybrid_streaming_callbacks_for_pipeline(
     - For async-capable components: uses async callbacks
     - For sync-only components: wraps sync callbacks for async context
 
+    When ``force_sync_callbacks`` is True, all callbacks are created as sync callbacks
+    that bridge to the async queue. This is required when running a sync ``Pipeline``
+    in the async streaming generator, because ``Pipeline.run()`` calls components'
+    ``run()`` methods which reject coroutine callbacks.
+
     Args:
         pipeline_run_args: Arguments for pipeline execution
         queue: Asyncio queue to put chunks into
         loop: The event loop to use for thread-safe operations
         all_streaming_components: Pre-computed list of all streaming components
         streaming_components: Optional config for which components should stream
+        force_sync_callbacks: When True, always create sync callbacks
 
     Returns:
         Updated pipeline run arguments
@@ -689,7 +706,9 @@ def _setup_hybrid_streaming_callbacks_for_pipeline(
         )
 
     for component, component_name in components_to_stream:
-        streaming_callback = _create_hybrid_streaming_callback(queue, component, component_name, loop)
+        streaming_callback = _create_hybrid_streaming_callback(
+            queue, component, component_name, loop, force_sync_callbacks=force_sync_callbacks
+        )
 
         # Copy component args to avoid mutating the original
         if component_name not in pipeline_run_args:
@@ -874,18 +893,33 @@ def async_streaming_generator(  # noqa: PLR0913, C901
 
     use_hybrid_mode = False
     all_streaming_components: list[tuple[Component, str]] = []
+    force_sync_callbacks = False
 
-    if isinstance(pipeline, (AsyncPipeline, Pipeline)):
+    if isinstance(pipeline, AsyncPipeline):
+        # Async pipeline: run_async() accepts async callbacks natively.
+        # Hybrid mode only needed when some components lack run_async.
         use_hybrid_mode, all_streaming_components = _validate_async_streaming_support(
             pipeline, allow_sync_streaming_callbacks
         )
+    elif isinstance(pipeline, Pipeline):
+        # Sync pipeline: Pipeline.run() calls components' run() synchronously,
+        # which rejects coroutine callbacks. Force hybrid mode with sync callbacks.
+        use_hybrid_mode = True
+        force_sync_callbacks = True
+        all_streaming_components = find_all_streaming_components(pipeline)
+    # else: Agent — run_async() natively accepts async callbacks, pure async path below.
 
     queue: asyncio.Queue[StreamingChunk] = asyncio.Queue()
     loop = asyncio.get_running_loop()
 
     if use_hybrid_mode:
         configured_args = _setup_hybrid_streaming_callbacks_for_pipeline(
-            pipeline_run_args, queue, loop, all_streaming_components, streaming_components
+            pipeline_run_args,
+            queue,
+            loop,
+            all_streaming_components,
+            streaming_components,
+            force_sync_callbacks=force_sync_callbacks,
         )
     else:
 

--- a/tests/test_it_pipeline_utils.py
+++ b/tests/test_it_pipeline_utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import os
 from collections.abc import AsyncGenerator, Generator
 from queue import Queue
@@ -91,17 +92,16 @@ def test_sync_pipeline_sync_streaming_callback_streaming_generator(sync_pipeline
     reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
 )
 @pytest.mark.integration
-async def test_sync_pipeline_async_streaming_generator_rejects_async_callback(
+async def test_sync_pipeline_async_streaming_generator_streams(
     sync_pipeline_with_sync_streaming_callback_support,
 ):
     """
-    Test that sync Pipeline with OpenAIChatGenerator rejects async streaming callbacks.
+    Test that sync Pipeline with OpenAIChatGenerator works with async_streaming_generator.
 
-    When using async_streaming_generator with a sync Pipeline, the component's run() method
-    validates that the callback is not a coroutine. This test verifies that validation works.
+    When using async_streaming_generator with a sync Pipeline, the generator should
+    automatically detect the sync pipeline and use sync callbacks bridged to the async queue,
+    so the streaming chunks are emitted correctly without "coroutine callback" errors.
     """
-    from haystack.core.errors import PipelineRuntimeError
-
     pipeline = sync_pipeline_with_sync_streaming_callback_support
 
     async_generator = async_streaming_generator(
@@ -111,8 +111,13 @@ async def test_sync_pipeline_async_streaming_generator_rejects_async_callback(
         },
     )
 
-    with pytest.raises(PipelineRuntimeError, match="The runtime callback cannot be a coroutine"):
-        _ = [chunk async for chunk in async_generator]
+    chunks = [chunk async for chunk in async_generator]
+    assert len(chunks) > 0
+
+    streaming_chunks = [c for c in chunks if isinstance(c, StreamingChunk)]
+    assert len(streaming_chunks) > 0
+    assert isinstance(streaming_chunks[0], StreamingChunk)
+    assert any("Yes" in chunk.content for chunk in streaming_chunks)
 
 
 @pytest.mark.skipif(
@@ -1652,3 +1657,55 @@ async def test_async_streaming_generator_external_queue_interleaved(mocker, mock
     assert chunks[0] == mock_chunks[0]
     assert chunks[1] == {"type": "interleaved", "data": "added during run"}
     assert chunks[2] == mock_chunks[1]
+
+
+@pytest.mark.asyncio
+async def test_sync_pipeline_with_agent_like_streaming(mocker):
+    """
+    Regression test: sync Pipeline with a component that rejects coroutine callbacks.
+
+    When async_streaming_generator is used with a sync Pipeline containing a component
+    that validates the streaming_callback is not a coroutine (like Haystack Agent),
+    the generator should automatically use sync callbacks bridged to the async queue,
+    so streaming chunks are emitted without "The runtime callback cannot be a coroutine" errors.
+    """
+
+    class AgentLikeComponent:
+        """Mock component that rejects coroutine streaming callbacks (like Agent)."""
+
+        def __init__(self, has_async_run=True):
+            if has_async_run:
+                self.run_async = lambda: None
+
+        def run(self, messages=None, streaming_callback=None, **kwargs):
+            if streaming_callback is not None and inspect.iscoroutinefunction(streaming_callback):
+                raise ValueError("The runtime callback cannot be a coroutine.")
+            if streaming_callback:
+                streaming_callback(StreamingChunk(content="agent ", index=0))
+                streaming_callback(StreamingChunk(content="response", index=1))
+            return {"response": "ok"}
+
+    component = AgentLikeComponent(has_async_run=True)
+
+    pipeline = mocker.Mock(spec=Pipeline)
+    pipeline._spec_class = Pipeline
+    pipeline.walk.return_value = [("agent", component)]
+
+    def mock_run(data, **kwargs):
+        callback = data.get("agent", {}).get("streaming_callback")
+        assert callback is not None, "streaming_callback should be set"
+        assert not inspect.iscoroutinefunction(callback), "callback must be sync, not a coroutine"
+        if callback:
+            callback(StreamingChunk(content="agent ", index=0))
+            callback(StreamingChunk(content="response", index=1))
+        return {"agent": {"response": "ok"}}
+
+    pipeline.run.side_effect = mock_run
+
+    generator = async_streaming_generator(pipeline, pipeline_run_args={})
+    chunks = [chunk async for chunk in generator]
+
+    streaming_chunks = [c for c in chunks if isinstance(c, StreamingChunk)]
+    assert len(streaming_chunks) == 2
+    assert streaming_chunks[0].content == "agent "
+    assert streaming_chunks[1].content == "response"


### PR DESCRIPTION
### Bug
`async_streaming_generator` unconditionally created an async callback for all pipeline types. When the pipeline is a sync `Pipeline` (e.g. YAML with `async_enabled: false`), `Pipeline.run()` calls components' `run()` synchronously. Components like `Agent` reject coroutine callbacks with: `ValueError: The runtime callback cannot be a coroutine`.

### Why it happens
| Pipeline type | How `async_streaming_generator` runs it | What `Agent.run()` expects |
|---|---|---|
| `AsyncPipeline` | `pipeline.run_async()` — accepts async callbacks | async callback ✅ |
| `Agent` (direct) | `agent.run_async()` — accepts async callbacks | async callback ✅ |
| `Pipeline` (sync) | `asyncio.to_thread(pipeline.run)` — calls `run()` | **sync callback** ❌ |
The sync `Pipeline` path was producing an async callback, which broke at `Agent.run()`.

### Fix
When the pipeline is a sync `Pipeline`, force all callbacks to be sync, bridged to the async queue via `asyncio.run_coroutine_threadsafe`. The dispatch now has three clear branches:
| `isinstance` | Callback | Execution |
|---|---|---|
| `AsyncPipeline` | async (or per-component hybrid) | `run_async()` |
| `Pipeline` (sync) | **all sync**, bridged | `asyncio.to_thread(run)` |
| `Agent` (direct) | async | `run_async()` |

### Changes
`src/hayhooks/server/pipelines/streaming.py`:
- `_create_hybrid_streaming_callback` — new `force_sync_callbacks` kwarg; when `True`, always returns a sync callback bridged via `run_coroutine_threadsafe`.
- `_setup_hybrid_streaming_callbacks_for_pipeline` — forwards `force_sync_callbacks`.
- `async_streaming_generator` — restructured from nested `if` into `AsyncPipeline` / `Pipeline` / `Agent` branches.