### PR TITLE
chore: Temporarily add context7.json with URL and public key

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/deepset-ai/hayhooks",
+  "public_key": "pk_NBN5TVMCHF3kizc2thzwX"
+}


### PR DESCRIPTION
SImilar to PRs in Haystack, this PR temporarily adds a file for claiming ownership of https://context7.com/deepset-ai/hayhooks
- https://github.com/deepset-ai/haystack/pull/11008
- https://github.com/deepset-ai/haystack/pull/11014

This allows us to configure context7 for Hayhooks via the context7 web UI. I will delete the temporary file right after claiming ownership is completed.