### PR TITLE
Real-time tracing dashboard / high-contrast theme

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="./src/assets/haystack-icon.png" />

--- a/dashboard/src/api.test.ts
+++ b/dashboard/src/api.test.ts
@@ -28,6 +28,7 @@ describe("normalizeDashboardConfig", () => {
       freshMs: 3000,
       slowComponentMinDurationMs: 1750,
       apiBase: "",
+      streamEnabled: true,
     })
   })
 

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -37,6 +37,7 @@ function isTraceSpanNode(value: unknown): value is TraceSummary["root_span"] {
     typeof value.name !== "string" ||
     !isFiniteNumber(value.start_time_ms) ||
     !isFiniteNumber(value.duration_ms) ||
+    (value.running !== undefined && typeof value.running !== "boolean") ||
     !Array.isArray(value.children) ||
     !isOptionalTraceTags(value.tags)
   ) {
@@ -102,6 +103,30 @@ function parseTraceCursor(headerValue: string | null): number | null {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : null
 }
 
+/**
+ * Validate and normalize a traces payload (the `{ traces, next_after_seq, has_more }`
+ * shape returned by both `GET /traces` and the SSE stream's `snapshot`/`trace`
+ * events). When the body omits `next_after_seq`, falls back to the optional
+ * response-header cursor.
+ */
+export function parseTracesPayload(payload: unknown, headerCursor?: string | null): FetchTracesResult {
+  if (!isRecord(payload) || !Array.isArray(payload.traces) || payload.traces.some((trace) => !isTraceSummary(trace))) {
+    throw new Error("Traces payload invalid")
+  }
+
+  const nextAfterSeqFromBody = typeof payload.next_after_seq === "number" && Number.isFinite(payload.next_after_seq)
+    ? payload.next_after_seq as number
+    : null
+  const hasMore = typeof payload.has_more === "boolean" ? payload.has_more : false
+  const nextAfterSeq = nextAfterSeqFromBody ?? (headerCursor !== undefined ? parseTraceCursor(headerCursor) : null)
+
+  return {
+    traces: payload.traces,
+    nextAfterSeq,
+    hasMore,
+  }
+}
+
 export async function fetchTraces(
   base: string,
   limit: number,
@@ -116,21 +141,14 @@ export async function fetchTraces(
   if (!response.ok) throw new Error(`Traces ${response.status}`)
 
   const payload = await response.json()
-  if (!isRecord(payload) || !Array.isArray(payload.traces) || payload.traces.some((trace) => !isTraceSummary(trace))) {
-    throw new Error("Traces payload invalid")
-  }
+  return parseTracesPayload(payload, response.headers.get("X-Hayhooks-Trace-Cursor"))
+}
 
-  const nextAfterSeqFromBody = typeof payload.next_after_seq === "number" && Number.isFinite(payload.next_after_seq)
-    ? payload.next_after_seq as number
-    : null
-  const hasMore = typeof payload.has_more === "boolean" ? payload.has_more : false
-  const nextAfterSeq = nextAfterSeqFromBody ?? parseTraceCursor(response.headers.get("X-Hayhooks-Trace-Cursor"))
-
-  return {
-    traces: payload.traces,
-    nextAfterSeq,
-    hasMore,
-  }
+export function traceStreamUrl(base: string, afterSeq?: number | null): string {
+  const params = new URLSearchParams()
+  if (afterSeq != null) params.set("after_seq", String(afterSeq))
+  const query = params.toString()
+  return query ? `${base}/traces/stream?${query}` : `${base}/traces/stream`
 }
 
 export async function clearTraces(base: string): Promise<void> {

--- a/dashboard/src/components/SpanRow.test.tsx
+++ b/dashboard/src/components/SpanRow.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react"
+import { SpanRow } from "./SpanRow"
+import type { TraceSpanNode } from "../types"
+
+function makeSpan(overrides: Partial<TraceSpanNode> = {}): TraceSpanNode {
+  return {
+    span_id: "s1",
+    name: "haystack.component.run",
+    start_time_ms: 1000,
+    duration_ms: 0,
+    children: [],
+    ...overrides,
+  }
+}
+
+const baseProps = {
+  depth: 0,
+  traceStart: 1000,
+  traceDuration: 0,
+  traceEntrypoint: "my_pipeline",
+  slowSpanId: null,
+  selectedSpanId: "",
+  onSelectSpan: () => {},
+}
+
+describe("SpanRow", () => {
+  it("renders a running span with a live indicator and an indeterminate bar", () => {
+    const { container } = render(<SpanRow span={makeSpan({ running: true })} {...baseProps} />)
+
+    expect(screen.getByText("live")).toBeInTheDocument()
+    expect(container.querySelector(".waterfall-bar-running")).not.toBeNull()
+    expect(container.querySelector(".span-row-running")).not.toBeNull()
+    // It must not look like a finished 0ms span.
+    expect(screen.queryByText("0ms")).toBeNull()
+  })
+
+  it("renders a finished span with a duration and a static sized bar", () => {
+    const { container } = render(
+      <SpanRow span={makeSpan({ running: false, duration_ms: 120 })} {...baseProps} traceDuration={200} />,
+    )
+
+    expect(screen.queryByText("live")).toBeNull()
+    expect(container.querySelector(".waterfall-bar-running")).toBeNull()
+    expect(container.querySelector(".waterfall-bar")).not.toBeNull()
+  })
+
+  it("treats a missing running flag as finished (backward compatible)", () => {
+    const { container } = render(
+      <SpanRow span={makeSpan({ duration_ms: 50 })} {...baseProps} traceDuration={200} />,
+    )
+
+    expect(screen.queryByText("live")).toBeNull()
+    expect(container.querySelector(".waterfall-bar-running")).toBeNull()
+  })
+})

--- a/dashboard/src/components/SpanRow.tsx
+++ b/dashboard/src/components/SpanRow.tsx
@@ -38,6 +38,7 @@ export const SpanRow = memo(function SpanRow({
     : undefined
   const isSlowComponent = slowSpanId === span.span_id
   const isSelected = span.span_id === selectedSpanId
+  const running = span.running === true
 
   return (
     <div className="space-y-1.5">
@@ -50,9 +51,11 @@ export const SpanRow = memo(function SpanRow({
           "flex w-full cursor-pointer items-center gap-2 rounded-md border px-2.5 py-2 text-left text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           isSelected
             ? "border-primary/40 bg-primary/10 shadow-sm"
-            : isSlowComponent
-              ? "border-warning-border bg-warning-soft hover:border-primary/30 hover:bg-warning/15"
-              : "border-border/40 hover:border-primary/30 hover:bg-muted",
+            : running
+              ? "span-row-running border-haystack-blue/40"
+              : isSlowComponent
+                ? "border-warning-border bg-warning-soft hover:border-primary/30 hover:bg-warning/15"
+                : "border-transparent hover:bg-muted",
         )}
       >
         <div className="min-w-0 grow" style={{ paddingLeft: depth * 16 }}>
@@ -77,13 +80,24 @@ export const SpanRow = memo(function SpanRow({
           </div>
         </div>
         <span className="w-14 shrink-0 text-right whitespace-nowrap tabular-nums text-muted-foreground">
-          {fmtDur(span.duration_ms)}
+          {running ? (
+            <span className="inline-flex items-center justify-end gap-1 font-sans text-[10px] font-semibold text-haystack-blue">
+              <span className="live-dot live-dot-ongoing" />
+              live
+            </span>
+          ) : (
+            fmtDur(span.duration_ms)
+          )}
         </span>
         <div className={cn("waterfall-track", isSelected && "waterfall-track-selected")}>
-          <div
-            className={cn("waterfall-bar", isSelected && "waterfall-bar-selected")}
-            style={{ marginLeft: `${offsetPct}%`, width: `${widthPct}%` }}
-          />
+          {running ? (
+            <div className="waterfall-bar-running" />
+          ) : (
+            <div
+              className={cn("waterfall-bar", isSelected && "waterfall-bar-selected")}
+              style={{ marginLeft: `${offsetPct}%`, width: `${widthPct}%` }}
+            />
+          )}
         </div>
       </button>
       {span.children.map((c) => (

--- a/dashboard/src/components/TraceCard.test.tsx
+++ b/dashboard/src/components/TraceCard.test.tsx
@@ -51,6 +51,53 @@ describe("TraceCard", () => {
     expect(container.querySelector(".trace-card-ongoing")).toBeFalsy()
   })
 
+  it("treats a trace as ongoing while its root span is running despite a leaked success tag", () => {
+    const trace = makeTrace({
+      duration_ms: 0,
+      root_span: makeSpan({ duration_ms: 0, running: true }),
+      tags: [{ key: "hayhooks.success", value: "true" }],
+    })
+    const { container } = render(<TraceCard trace={trace} isFresh={false} />)
+
+    expect(screen.getByText("ONGOING")).toBeInTheDocument()
+    expect(container.querySelector(".trace-card-ongoing")).toBeTruthy()
+  })
+
+  it("auto-expands an ongoing trace so its spans are visible", () => {
+    const trace = makeTrace({
+      duration_ms: 0,
+      root_span: makeSpan({ duration_ms: 0, running: true }),
+      tags: [],
+    })
+    render(<TraceCard trace={trace} isFresh={false} />)
+
+    // The collapsible trigger reflects expanded state via aria-expanded.
+    const triggers = screen.getAllByRole("button").filter((el) => el.getAttribute("aria-expanded") !== null)
+    expect(triggers[0]).toHaveAttribute("aria-expanded", "true")
+  })
+
+  it("keeps the latest trace expanded even after it has finished", () => {
+    const trace = makeTrace({
+      tags: [{ key: "hayhooks.success", value: "true" }],
+      root_span: makeSpan({ duration_ms: 100, running: false }),
+    })
+    render(<TraceCard trace={trace} isFresh={false} isLatest />)
+
+    const triggers = screen.getAllByRole("button").filter((el) => el.getAttribute("aria-expanded") !== null)
+    expect(triggers[0]).toHaveAttribute("aria-expanded", "true")
+  })
+
+  it("collapses an older finished trace that is neither latest nor ongoing", () => {
+    const trace = makeTrace({
+      tags: [{ key: "hayhooks.success", value: "true" }],
+      root_span: makeSpan({ duration_ms: 100, running: false }),
+    })
+    render(<TraceCard trace={trace} isFresh={false} isLatest={false} />)
+
+    const triggers = screen.getAllByRole("button").filter((el) => el.getAttribute("aria-expanded") !== null)
+    expect(triggers[0]).toHaveAttribute("aria-expanded", "false")
+  })
+
   it("uses failed fresh highlight when trace is fresh and failed", () => {
     const trace = makeTrace({
       tags: [{ key: "hayhooks.success", value: "false" }],

--- a/dashboard/src/components/TraceCard.tsx
+++ b/dashboard/src/components/TraceCard.tsx
@@ -18,15 +18,17 @@ import { SpanRow } from "./SpanRow"
 type TraceCardProps = {
   trace: TraceSummary
   isFresh: boolean
+  isLatest?: boolean
   slowComponentMinDurationMs?: number
 }
 
 export const TraceCard = memo(function TraceCard({
   trace,
   isFresh,
+  isLatest = false,
   slowComponentMinDurationMs = DEFAULT_DASHBOARD_CONFIG.slowComponentMinDurationMs,
 }: TraceCardProps) {
-  const [open, setOpen] = useState(false)
+  const [manualOpen, setManualOpen] = useState<boolean | null>(null)
   const [selectedSpanId, setSelectedSpanId] = useState(trace.root_span.span_id)
   const traceIdCopy = useCopyToClipboard()
   const summaryTags = useMemo(
@@ -47,6 +49,11 @@ export const TraceCard = memo(function TraceCard({
   const failed = isFailed(trace)
   const ongoing = isOngoing(trace)
   const streaming = isStreaming(trace)
+
+  // Keep the latest trace (and any still-ongoing one) expanded; older finished
+  // traces collapse to their compact header so the history stays light. A
+  // manual toggle overrides and sticks for the life of the card.
+  const open = manualOpen ?? (isLatest || ongoing)
   const kind = traceKind(trace)
   const kindStyle = KIND_STYLE[kind]
   const freshHighlightTone = failed ? "failed" : kind
@@ -69,7 +76,7 @@ export const TraceCard = memo(function TraceCard({
   }, [failed, trace.tags, trace.root_span])
 
   return (
-    <Collapsible open={open} onOpenChange={setOpen}>
+    <Collapsible open={open} onOpenChange={setManualOpen}>
       <div
         className={cn(
           "rounded-lg border border-l-2 bg-card text-card-foreground transition-shadow",

--- a/dashboard/src/components/TraceCards.tsx
+++ b/dashboard/src/components/TraceCards.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react"
+import { memo, useMemo } from "react"
 
 import { TooltipProvider } from "@/components/ui/tooltip"
 import type { TraceSummary } from "../types"
@@ -13,6 +13,16 @@ type TraceCardsProps = {
 export const TraceCards = memo(function TraceCards({ traces, slowComponentMinDurationMs }: TraceCardsProps) {
   const isFresh = useTraceFreshnessTimer(traces)
 
+  // The most recent trace by start time (independent of the list's sort mode);
+  // it stays auto-expanded so the latest run is always in view.
+  const latestTraceId = useMemo(() => {
+    let latest: TraceSummary | null = null
+    for (const trace of traces) {
+      if (latest === null || trace.start_time_ms > latest.start_time_ms) latest = trace
+    }
+    return latest?.trace_id ?? null
+  }, [traces])
+
   return (
     <TooltipProvider delay={200}>
       <div className="space-y-2 pr-3">
@@ -21,6 +31,7 @@ export const TraceCards = memo(function TraceCards({ traces, slowComponentMinDur
             key={trace.trace_id}
             trace={trace}
             isFresh={isFresh(trace.trace_id)}
+            isLatest={trace.trace_id === latestTraceId}
             slowComponentMinDurationMs={slowComponentMinDurationMs}
           />
         ))}

--- a/dashboard/src/constants.ts
+++ b/dashboard/src/constants.ts
@@ -7,6 +7,7 @@ export const DEFAULT_DASHBOARD_CONFIG: DashboardConfig = {
   freshMs: 6000,
   slowComponentMinDurationMs: 1000,
   apiBase: "",
+  streamEnabled: true,
 }
 
 export const TAG_PRIORITY = [

--- a/dashboard/src/hooks/useTraces.stream.test.ts
+++ b/dashboard/src/hooks/useTraces.stream.test.ts
@@ -148,4 +148,24 @@ describe("useTraces (SSE)", () => {
     // Third failure crosses the threshold and triggers a polling fetch.
     await waitFor(() => expect(mockedApi.fetchTraces).toHaveBeenCalled())
   })
+
+  it("falls back when the connection flaps (open then error) without ever delivering data", async () => {
+    mockedApi.fetchTraces.mockResolvedValue(makeFetchResult({ traces: [makeTrace()], nextAfterSeq: 5 }))
+    renderHook(() => useTraces(STREAM_CONFIG))
+    await waitFor(() => expect(MockEventSource.instances).toHaveLength(1))
+    const source = MockEventSource.instances[0]
+
+    // open must NOT reset the failure counter — otherwise a flapping connection
+    // that never sends a payload would bounce below the threshold forever.
+    act(() => {
+      source.emit("open")
+      source.emit("error")
+      source.emit("open")
+      source.emit("error")
+      source.emit("open")
+      source.emit("error")
+    })
+
+    await waitFor(() => expect(mockedApi.fetchTraces).toHaveBeenCalled())
+  })
 })

--- a/dashboard/src/hooks/useTraces.stream.test.ts
+++ b/dashboard/src/hooks/useTraces.stream.test.ts
@@ -1,0 +1,151 @@
+import { renderHook, act, waitFor } from "@testing-library/react"
+import { useTraces } from "./useTraces"
+import type { DashboardConfig, TraceSummary } from "../types"
+import * as api from "../api"
+import type { FetchTracesResult } from "../api"
+
+function makeTrace(overrides: Partial<TraceSummary> = {}): TraceSummary {
+  return {
+    trace_id: "trace-1",
+    start_time_ms: 1000,
+    duration_ms: 200,
+    entrypoint: "my_pipeline",
+    span_count: 1,
+    root_span: { span_id: "s1", name: "root", start_time_ms: 1000, duration_ms: 200, children: [] },
+    tags: [],
+    ...overrides,
+  }
+}
+
+function makeFetchResult(overrides: Partial<FetchTracesResult> = {}): FetchTracesResult {
+  return { traces: [], nextAfterSeq: null, hasMore: false, ...overrides }
+}
+
+type Listener = (event: { data?: string }) => void
+
+class MockEventSource {
+  static instances: MockEventSource[] = []
+  url: string
+  closed = false
+  private listeners: Record<string, Listener[]> = {}
+
+  constructor(url: string) {
+    this.url = url
+    MockEventSource.instances.push(this)
+  }
+
+  addEventListener(type: string, cb: Listener) {
+    ;(this.listeners[type] ||= []).push(cb)
+  }
+
+  removeEventListener() {
+    /* not needed for these tests */
+  }
+
+  close() {
+    this.closed = true
+  }
+
+  emit(type: string, data?: string) {
+    for (const cb of this.listeners[type] ?? []) cb({ data })
+  }
+}
+
+const STREAM_CONFIG: DashboardConfig = {
+  pollMs: 600_000,
+  listCap: 100,
+  fetchLimit: 50,
+  freshMs: 5000,
+  slowComponentMinDurationMs: 1000,
+  apiBase: "",
+  streamEnabled: true,
+}
+
+vi.mock("../api", async (importOriginal) => {
+  const actual = await importOriginal<typeof api>()
+  return {
+    ...actual,
+    resolveApiBase: () => "http://test",
+    fetchEntrypoints: vi.fn().mockResolvedValue([]),
+    fetchTraces: vi.fn().mockResolvedValue(makeFetchResult()),
+    clearTraces: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+const mockedApi = vi.mocked(api)
+
+beforeEach(() => {
+  MockEventSource.instances = []
+  ;(globalThis as unknown as { EventSource: unknown }).EventSource = MockEventSource
+  mockedApi.fetchEntrypoints.mockReset().mockResolvedValue([])
+  mockedApi.fetchTraces.mockReset().mockResolvedValue(makeFetchResult())
+  mockedApi.clearTraces.mockReset().mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  delete (globalThis as unknown as { EventSource?: unknown }).EventSource
+})
+
+describe("useTraces (SSE)", () => {
+  it("opens an EventSource to the stream endpoint and applies pushed traces", async () => {
+    const { result } = renderHook(() => useTraces(STREAM_CONFIG))
+
+    await waitFor(() => expect(MockEventSource.instances).toHaveLength(1))
+    const source = MockEventSource.instances[0]
+    expect(source.url).toContain("/traces/stream")
+
+    act(() => {
+      source.emit("open")
+      source.emit(
+        "snapshot",
+        JSON.stringify({ traces: [makeTrace()], next_after_seq: 1, has_more: false }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(result.current.traces).toHaveLength(1)
+      expect(result.current.traces[0].trace_id).toBe("trace-1")
+    })
+
+    // No polling while the stream is healthy.
+    expect(mockedApi.fetchTraces).not.toHaveBeenCalled()
+  })
+
+  it("merges subsequent trace delta events", async () => {
+    const { result } = renderHook(() => useTraces(STREAM_CONFIG))
+    await waitFor(() => expect(MockEventSource.instances).toHaveLength(1))
+    const source = MockEventSource.instances[0]
+
+    act(() => {
+      source.emit("open")
+      source.emit("snapshot", JSON.stringify({ traces: [makeTrace()], next_after_seq: 1, has_more: false }))
+    })
+    await waitFor(() => expect(result.current.traces).toHaveLength(1))
+
+    act(() => {
+      source.emit(
+        "trace",
+        JSON.stringify({ traces: [makeTrace({ trace_id: "trace-2", start_time_ms: 2000 })], next_after_seq: 2, has_more: false }),
+      )
+    })
+
+    await waitFor(() => expect(result.current.traces).toHaveLength(2))
+  })
+
+  it("falls back to polling after repeated stream errors", async () => {
+    mockedApi.fetchTraces.mockResolvedValue(makeFetchResult({ traces: [makeTrace()], nextAfterSeq: 5 }))
+    renderHook(() => useTraces(STREAM_CONFIG))
+    await waitFor(() => expect(MockEventSource.instances).toHaveLength(1))
+    const source = MockEventSource.instances[0]
+
+    act(() => {
+      source.emit("error")
+      source.emit("error")
+      source.emit("error")
+    })
+
+    // Third failure crosses the threshold and triggers a polling fetch.
+    await waitFor(() => expect(mockedApi.fetchTraces).toHaveBeenCalled())
+  })
+})

--- a/dashboard/src/hooks/useTraces.test.ts
+++ b/dashboard/src/hooks/useTraces.test.ts
@@ -45,6 +45,8 @@ const TEST_CONFIG: DashboardConfig = {
   freshMs: 5000,
   slowComponentMinDurationMs: 1000,
   apiBase: "",
+  // These tests exercise the polling/merge path; SSE is covered separately.
+  streamEnabled: false,
 }
 
 vi.mock("../api", async (importOriginal) => {

--- a/dashboard/src/hooks/useTraces.ts
+++ b/dashboard/src/hooks/useTraces.ts
@@ -273,8 +273,10 @@ export function useTraces(config: DashboardConfig): UseTracesResult {
     let source: EventSource | null = null
     let pollInterval: number | null = null
     let failures = 0
+    let gotData = false
     let disposed = false
     const FAILURE_THRESHOLD = 3
+    const CONNECT_TIMEOUT_MS = 4000
 
     const stopPolling = () => {
       if (pollInterval !== null) {
@@ -303,6 +305,13 @@ export function useTraces(config: DashboardConfig): UseTracesResult {
       try {
         const result = parseTracesPayload(JSON.parse(raw))
         if (result.nextAfterSeq !== null) afterSeqRef.current = result.nextAfterSeq
+        // The stream is genuinely delivering data: only now is it safe to treat
+        // it as healthy. Resetting on `open` instead would let a connection that
+        // flaps (open → error → open …) without ever delivering a payload bounce
+        // below FAILURE_THRESHOLD forever and never fall back to polling.
+        gotData = true
+        failures = 0
+        stopPolling()
         applyIncoming(result.traces)
       } catch {
         /* ignore malformed SSE frame */
@@ -310,12 +319,14 @@ export function useTraces(config: DashboardConfig): UseTracesResult {
     }
 
     source = new EventSource(traceStreamUrl(base, afterSeqRef.current))
-    source.addEventListener("open", () => {
-      failures = 0
-      stopPolling()
-      loadEntrypoints()
-      setState((prev) => (prev.error === null ? prev : { ...prev, error: null }))
-    })
+    // Safety net: if the stream never delivers data (e.g. `open` never fires, or
+    // it opens then stalls), fall back to polling so the UI is never left blank
+    // or stale with no error surfaced.
+    const watchdog = window.setTimeout(() => {
+      if (!disposed && !gotData) startPollingFallback()
+    }, CONNECT_TIMEOUT_MS)
+
+    source.addEventListener("open", loadEntrypoints)
     source.addEventListener("snapshot", (event) => handlePayload((event as MessageEvent<string>).data))
     source.addEventListener("trace", (event) => handlePayload((event as MessageEvent<string>).data))
     source.addEventListener("error", () => {
@@ -326,6 +337,7 @@ export function useTraces(config: DashboardConfig): UseTracesResult {
 
     return () => {
       disposed = true
+      window.clearTimeout(watchdog)
       stopPolling()
       source?.close()
     }

--- a/dashboard/src/hooks/useTraces.ts
+++ b/dashboard/src/hooks/useTraces.ts
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react"
-import { clearTraces as apiClearTraces, fetchEntrypoints, fetchTraces, resolveApiBase } from "../api"
+import {
+  clearTraces as apiClearTraces,
+  fetchEntrypoints,
+  fetchTraces,
+  parseTracesPayload,
+  resolveApiBase,
+  traceStreamUrl,
+} from "../api"
 import type { DashboardConfig, TraceSummary } from "../types"
 import { mergeTraces } from "../utils/traces"
 
@@ -74,6 +81,10 @@ function computeFreshUntil(
 
 export function useTraces(config: DashboardConfig): UseTracesResult {
   const [state, setState] = useState<State>(INITIAL_STATE)
+  // Bumped by clear() to force the SSE connection to reconnect (the server
+  // resets its cursor on clear, so an open stream must restart from a fresh
+  // snapshot to keep receiving new traces).
+  const [streamEpoch, setStreamEpoch] = useState(0)
 
   /**
    * Refs carry imperative state between refresh cycles without triggering
@@ -99,6 +110,34 @@ export function useTraces(config: DashboardConfig): UseTracesResult {
       mountedRef.current = false
     }
   }, [])
+
+  /**
+   * Apply an incoming batch of traces to visible state: track freshness for
+   * genuinely new traces, then merge/dedup/cap. Shared by the polling path and
+   * the SSE stream so both produce identical state transitions.
+   */
+  const applyIncoming = useCallback(
+    (incoming: TraceSummary[]) => {
+      const now = Date.now()
+      const incomingIds = incoming.map((t) => t.trace_id)
+      const freshUntil = computeFreshUntil(freshUntilRef.current, incomingIds, seenRef.current, now, config.freshMs)
+      for (const id of incomingIds) seenRef.current.add(id)
+
+      const currentTraces = tracesRef.current
+      const capped = currentTraces.length > config.listCap ? currentTraces.slice(0, config.listCap) : currentTraces
+      const nextTraces = incoming.length === 0 ? capped : mergeTraces(capped, incoming, config.listCap)
+
+      if (incoming.length === 0 && capped !== currentTraces) {
+        seenRef.current = new Set(capped.map((t) => t.trace_id))
+      }
+      if (nextTraces !== capped) {
+        seenRef.current = new Set(nextTraces.map((t) => t.trace_id))
+      }
+
+      setState((prev) => ({ ...prev, traces: nextTraces, freshUntil, updatedAt: now, error: null }))
+    },
+    [config.freshMs, config.listCap],
+  )
 
   const refresh = useCallback(
     async (options?: { silent?: boolean }) => {
@@ -156,36 +195,8 @@ export function useTraces(config: DashboardConfig): UseTracesResult {
           if (nextAfterSeq !== null) afterSeqRef.current = nextAfterSeq
         }
 
-        // 3. Track freshness
-        const now = Date.now()
-        const incomingIds = incoming.map((t) => t.trace_id)
-        const freshUntil = computeFreshUntil(freshUntilRef.current, incomingIds, seenRef.current, now, config.freshMs)
-        for (const id of incomingIds) seenRef.current.add(id)
-
-        // 4. Merge incoming traces into the visible list
-        const currentTraces = tracesRef.current
-        const capped = currentTraces.length > config.listCap
-          ? currentTraces.slice(0, config.listCap)
-          : currentTraces
-
-        const nextTraces = incoming.length === 0
-          ? capped
-          : mergeTraces(capped, incoming, config.listCap)
-
-        if (incoming.length === 0 && capped !== currentTraces) {
-          seenRef.current = new Set(capped.map((t) => t.trace_id))
-        }
-        if (nextTraces !== capped) {
-          seenRef.current = new Set(nextTraces.map((t) => t.trace_id))
-        }
-
-        setState((prev) => ({
-          ...prev,
-          traces: nextTraces,
-          freshUntil,
-          updatedAt: now,
-          error: null,
-        }))
+        // 3. Track freshness + merge into the visible list (shared with SSE).
+        applyIncoming(incoming)
 
         if (!isCurrent()) return
       } catch (e) {
@@ -204,7 +215,7 @@ export function useTraces(config: DashboardConfig): UseTracesResult {
         return mountedRef.current && epoch === epochRef.current
       }
     },
-    [config.fetchLimit, config.freshMs, config.listCap],
+    [applyIncoming, config.fetchLimit],
   )
 
   const clear = useCallback(async () => {
@@ -224,6 +235,9 @@ export function useTraces(config: DashboardConfig): UseTracesResult {
         error: null,
         clearing: false,
       }))
+      // Force the SSE stream to reconnect from a fresh (empty) snapshot, since
+      // the server resets its trace cursor on clear.
+      setStreamEpoch((epoch) => epoch + 1)
     } catch (e) {
       if (mountedRef.current) {
         setState((prev) => ({
@@ -236,18 +250,86 @@ export function useTraces(config: DashboardConfig): UseTracesResult {
   }, [])
 
   /**
-   * Initial fetch fires immediately (via setTimeout 0), then repeats on the
-   * configured interval. Both use "silent" mode so the UI doesn't flash the
-   * loading indicator on background polls.
+   * Live updates.
+   *
+   * Primary path is an SSE stream (`EventSource`): the server pushes a
+   * `snapshot` on connect, then `trace` deltas as spans start/finish. If the
+   * stream can't connect or repeatedly errors, we fall back to interval polling
+   * until it recovers — and when SSE is disabled by the server (or unavailable
+   * in the runtime) we use polling directly, preserving the original behavior.
    */
   useEffect(() => {
-    const timeout = window.setTimeout(() => void refresh({ silent: true }), 0)
-    const interval = window.setInterval(() => void refresh({ silent: true }), config.pollMs)
-    return () => {
-      window.clearTimeout(timeout)
-      window.clearInterval(interval)
+    const base = baseRef.current
+
+    if (!config.streamEnabled || typeof EventSource === "undefined") {
+      const timeout = window.setTimeout(() => void refresh({ silent: true }), 0)
+      const interval = window.setInterval(() => void refresh({ silent: true }), config.pollMs)
+      return () => {
+        window.clearTimeout(timeout)
+        window.clearInterval(interval)
+      }
     }
-  }, [config.pollMs, refresh])
+
+    let source: EventSource | null = null
+    let pollInterval: number | null = null
+    let failures = 0
+    let disposed = false
+    const FAILURE_THRESHOLD = 3
+
+    const stopPolling = () => {
+      if (pollInterval !== null) {
+        window.clearInterval(pollInterval)
+        pollInterval = null
+      }
+    }
+    const startPollingFallback = () => {
+      if (pollInterval !== null) return
+      void refresh({ silent: true })
+      pollInterval = window.setInterval(() => void refresh({ silent: true }), config.pollMs)
+    }
+
+    const loadEntrypoints = () => {
+      void fetchEntrypoints(base)
+        .then((next) => {
+          if (disposed) return
+          setState((prev) => (sameStrings(prev.entrypoints, next) ? prev : { ...prev, entrypoints: next }))
+        })
+        .catch(() => {
+          /* entrypoints are best-effort; ignore transient failures */
+        })
+    }
+
+    const handlePayload = (raw: string) => {
+      try {
+        const result = parseTracesPayload(JSON.parse(raw))
+        if (result.nextAfterSeq !== null) afterSeqRef.current = result.nextAfterSeq
+        applyIncoming(result.traces)
+      } catch {
+        /* ignore malformed SSE frame */
+      }
+    }
+
+    source = new EventSource(traceStreamUrl(base, afterSeqRef.current))
+    source.addEventListener("open", () => {
+      failures = 0
+      stopPolling()
+      loadEntrypoints()
+      setState((prev) => (prev.error === null ? prev : { ...prev, error: null }))
+    })
+    source.addEventListener("snapshot", (event) => handlePayload((event as MessageEvent<string>).data))
+    source.addEventListener("trace", (event) => handlePayload((event as MessageEvent<string>).data))
+    source.addEventListener("error", () => {
+      // EventSource auto-reconnects; after repeated failures, fall back to polling.
+      failures += 1
+      if (failures >= FAILURE_THRESHOLD) startPollingFallback()
+    })
+
+    return () => {
+      disposed = true
+      stopPolling()
+      source?.close()
+    }
+  }, [config.streamEnabled, config.pollMs, streamEpoch, refresh, applyIncoming])
 
   return {
     entrypoints: state.entrypoints,

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -57,53 +57,53 @@
 }
 
 .dark {
-  --haystack-green: #4ade80;
-  --haystack-blue: #60a5fa;
-  --warning: #fbbf24;
-  --warning-soft: rgb(245 158 11 / 12%);
-  --warning-border: rgb(245 158 11 / 35%);
-  --kind-deploy: #fbbf24;
-  --kind-deploy-soft: rgb(245 158 11 / 15%);
-  --kind-deploy-border: rgb(245 158 11 / 30%);
-  --kind-openai: #c4b5fd;
-  --kind-openai-soft: rgb(139 92 246 / 15%);
-  --kind-openai-border: rgb(139 92 246 / 30%);
-  --kind-mcp: #5eead4;
-  --kind-mcp-soft: rgb(20 184 166 / 15%);
-  --kind-mcp-border: rgb(20 184 166 / 30%);
-  --stream: #22d3ee;
-  --background: #0f1117;
-  --foreground: #e2e8f0;
-  --card: #181b23;
-  --card-foreground: #e2e8f0;
-  --popover: #181b23;
-  --popover-foreground: #e2e8f0;
-  --primary: #60a5fa;
-  --primary-foreground: #0f1117;
-  --secondary: #1e2130;
-  --secondary-foreground: #cbd5e1;
-  --muted: #1e2130;
-  --muted-foreground: #94a3b8;
-  --accent: #1e2130;
-  --accent-foreground: #e2e8f0;
-  --destructive: #f87171;
+  --haystack-green: #5cf08f;
+  --haystack-blue: #74b4ff;
+  --warning: #ffd43b;
+  --warning-soft: color-mix(in srgb, var(--warning) 8%, transparent);
+  --warning-border: color-mix(in srgb, var(--warning) 60%, transparent);
+  --kind-deploy: #ffa94d;
+  --kind-deploy-soft: color-mix(in srgb, var(--kind-deploy) 10%, transparent);
+  --kind-deploy-border: color-mix(in srgb, var(--kind-deploy) 52%, transparent);
+  --kind-openai: #b197fc;
+  --kind-openai-soft: color-mix(in srgb, var(--kind-openai) 18%, transparent);
+  --kind-openai-border: color-mix(in srgb, var(--kind-openai) 45%, transparent);
+  --kind-mcp: #3bf7d4;
+  --kind-mcp-soft: color-mix(in srgb, var(--kind-mcp) 16%, transparent);
+  --kind-mcp-border: color-mix(in srgb, var(--kind-mcp) 45%, transparent);
+  --stream: #38d9f5;
+  --background: #08090c;
+  --foreground: #f5f7fa;
+  --card: #101216;
+  --card-foreground: #f5f7fa;
+  --popover: #101216;
+  --popover-foreground: #f5f7fa;
+  --primary: #74b4ff;
+  --primary-foreground: #08090c;
+  --secondary: #1a1d24;
+  --secondary-foreground: #e2e8f0;
+  --muted: #1a1d24;
+  --muted-foreground: #aab4c0;
+  --accent: #1a1d24;
+  --accent-foreground: #f5f7fa;
+  --destructive: #ff6b6b;
   --destructive-foreground: #1f0a0a;
-  --border: rgb(255 255 255 / 8%);
-  --input: rgb(255 255 255 / 10%);
-  --ring: #60a5fa;
-  --chart-1: #60a5fa;
-  --chart-2: #4ade80;
-  --chart-3: #fbbf24;
+  --border: rgb(255 255 255 / 14%);
+  --input: rgb(255 255 255 / 16%);
+  --ring: #74b4ff;
+  --chart-1: #74b4ff;
+  --chart-2: #5cf08f;
+  --chart-3: #ffd43b;
   --chart-4: #a78bfa;
   --chart-5: #f472b6;
-  --sidebar: #13151d;
-  --sidebar-foreground: #e2e8f0;
-  --sidebar-primary: #60a5fa;
-  --sidebar-primary-foreground: #0f1117;
-  --sidebar-accent: #1e2130;
-  --sidebar-accent-foreground: #e2e8f0;
-  --sidebar-border: rgb(255 255 255 / 8%);
-  --sidebar-ring: #60a5fa;
+  --sidebar: #0b0c10;
+  --sidebar-foreground: #f5f7fa;
+  --sidebar-primary: #74b4ff;
+  --sidebar-primary-foreground: #08090c;
+  --sidebar-accent: #1a1d24;
+  --sidebar-accent-foreground: #f5f7fa;
+  --sidebar-border: rgb(255 255 255 / 14%);
+  --sidebar-ring: #74b4ff;
 }
 
 @theme inline {
@@ -198,8 +198,8 @@
 
 .waterfall-bar-selected {
   box-shadow:
-    0 0 0 1px rgb(46 108 223 / 68%),
-    0 0 0 3px rgb(46 108 223 / 16%);
+    0 0 0 1px color-mix(in srgb, var(--haystack-blue) 68%, transparent),
+    0 0 0 3px color-mix(in srgb, var(--haystack-blue) 16%, transparent);
 }
 
 /* Animate new trace cards */
@@ -236,50 +236,37 @@
     trace-enter 400ms ease-out,
     trace-glow 2s ease-in-out infinite;
   --glow-color: var(--haystack-blue);
-  --glow-color-soft: rgb(46 108 223 / 20%);
+  --glow-color-soft: color-mix(in srgb, var(--glow-color) 22%, transparent);
   border-top-color: var(--glow-color);
   border-right-color: var(--glow-color);
   border-bottom-color: var(--glow-color);
 }
 
+/* Each variant only sets --glow-color; the soft glow derives from it, and the
+   token vars already swap per theme, so no light/dark overrides are needed. */
 .trace-card-fresh-deploy {
-  --glow-color: #f59e0b;
-  --glow-color-soft: rgb(245 158 11 / 20%);
+  --glow-color: var(--kind-deploy);
 }
 
-.trace-card-fresh-undeploy {
-  --glow-color: #94a3b8;
-  --glow-color-soft: rgb(148 163 184 / 18%);
+.trace-card-fresh-undeploy,
+.trace-card-fresh-other {
+  --glow-color: var(--muted-foreground);
 }
 
 .trace-card-fresh-openai {
-  --glow-color: #8b5cf6;
-  --glow-color-soft: rgb(139 92 246 / 20%);
+  --glow-color: var(--kind-openai);
 }
 
 .trace-card-fresh-mcp {
-  --glow-color: #14b8a6;
-  --glow-color-soft: rgb(20 184 166 / 20%);
+  --glow-color: var(--kind-mcp);
 }
 
 .trace-card-fresh-run {
   --glow-color: var(--haystack-blue);
-  --glow-color-soft: rgb(46 108 223 / 20%);
-}
-
-.trace-card-fresh-other {
-  --glow-color: #94a3b8;
-  --glow-color-soft: rgb(148 163 184 / 18%);
 }
 
 .trace-card-fresh-failed {
-  --glow-color: #dc2626;
-  --glow-color-soft: rgb(220 38 38 / 22%);
-}
-
-.dark .trace-card-fresh-failed {
-  --glow-color: #f87171;
-  --glow-color-soft: rgb(248 113 113 / 24%);
+  --glow-color: var(--destructive);
 }
 
 /* Animate ongoing traces — only the outer glow pulses; the border stays a
@@ -295,8 +282,7 @@
 }
 
 .trace-card-ongoing {
-  --ongoing-strong: rgb(46 108 223 / 52%);
-  --ongoing-soft: rgb(46 108 223 / 16%);
+  --ongoing-strong: color-mix(in srgb, var(--haystack-blue) 55%, transparent);
   border-top-color: var(--ongoing-strong);
   border-right-color: var(--ongoing-strong);
   border-bottom-color: var(--ongoing-strong);

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -202,6 +202,45 @@
     0 0 0 3px color-mix(in srgb, var(--haystack-blue) 16%, transparent);
 }
 
+/* In-progress span: an indeterminate stripe sweeping across the track so a
+   running span reads as "live" even before it has a measurable duration. */
+@keyframes waterfall-running {
+  0% {
+    transform: translateX(-120%);
+  }
+  100% {
+    transform: translateX(260%);
+  }
+}
+
+.waterfall-bar-running {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 45%;
+  border-radius: 4px;
+  background: linear-gradient(90deg, transparent, var(--haystack-blue), var(--haystack-green), transparent);
+  animation: waterfall-running 1.2s ease-in-out infinite;
+  will-change: transform;
+}
+
+/* Gentle pulsing glow on the row of a span that is still running. */
+@keyframes span-row-glow {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+  50% {
+    box-shadow: 0 0 12px -4px color-mix(in srgb, var(--haystack-blue) 55%, transparent);
+  }
+}
+
+.span-row-running {
+  background: color-mix(in srgb, var(--haystack-blue) 8%, transparent);
+  animation: span-row-glow 1.6s ease-in-out infinite;
+}
+
 /* Animate new trace cards */
 @keyframes trace-enter {
   from {
@@ -269,24 +308,47 @@
   --glow-color: var(--destructive);
 }
 
-/* Animate ongoing traces — only the outer glow pulses; the border stays a
-   constant blue so we never see two adjacent rings. */
-@keyframes trace-ongoing {
-  0%,
-  100% {
-    box-shadow: 0 0 0 0 transparent;
-  }
-  50% {
-    box-shadow: 0 0 24px -8px var(--ongoing-strong);
+/* Ongoing traces: a "border beam" — a bright segment of the Haystack gradient
+   orbits the card's perimeter to signal live activity. Distinct from the
+   `trace-card-fresh` glow so ongoing never reads the same as just-arrived. */
+@property --ongoing-beam-angle {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+
+@keyframes trace-ongoing-beam {
+  to {
+    --ongoing-beam-angle: 360deg;
   }
 }
 
 .trace-card-ongoing {
-  --ongoing-strong: color-mix(in srgb, var(--haystack-blue) 55%, transparent);
-  border-top-color: var(--ongoing-strong);
-  border-right-color: var(--ongoing-strong);
-  border-bottom-color: var(--ongoing-strong);
-  animation: trace-ongoing 1.6s ease-in-out infinite;
+  position: relative;
+}
+
+.trace-card-ongoing::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  padding: 1.5px;
+  border-radius: inherit;
+  background: conic-gradient(
+    from var(--ongoing-beam-angle),
+    transparent 60%,
+    var(--haystack-blue) 80%,
+    var(--haystack-green) 92%,
+    transparent 100%
+  );
+  /* Mask to just the border ring (show only the padding band). */
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+  animation: trace-ongoing-beam 2.6s linear infinite;
 }
 
 /* Live pulse indicator */
@@ -315,9 +377,22 @@
 @media (prefers-reduced-motion: reduce) {
   .trace-card-fresh,
   .trace-card-ongoing,
+  .trace-card-ongoing::before,
   .live-dot,
-  .live-dot-ongoing {
+  .live-dot-ongoing,
+  .waterfall-bar-running,
+  .span-row-running {
     animation: none !important;
+  }
+  /* Keep a visible (static) running indicator when motion is reduced. */
+  .waterfall-bar-running {
+    width: 100%;
+    background: linear-gradient(90deg, var(--haystack-blue), var(--haystack-green));
+    opacity: 0.55;
+  }
+  /* Static uniform border ring instead of a frozen beam arc. */
+  .trace-card-ongoing::before {
+    background: color-mix(in srgb, var(--haystack-blue) 45%, transparent);
   }
 }
 

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -1,4 +1,6 @@
-import '@fontsource/inter'
+import '@fontsource/inter/400.css'
+import '@fontsource/inter/500.css'
+import '@fontsource/inter/600.css'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -5,6 +5,7 @@ export type TraceSpanNode = {
   name: string
   start_time_ms: number
   duration_ms: number
+  running?: boolean
   tags?: TraceTag[]
   children: TraceSpanNode[]
 }
@@ -26,6 +27,7 @@ export type DashboardConfigResponse = {
   fresh_ms: number
   slow_component_min_duration_ms: number
   api_base: string
+  stream_enabled: boolean
 }
 
 export type SortMode = "newest" | "slowest"
@@ -38,4 +40,5 @@ export type DashboardConfig = {
   freshMs: number
   slowComponentMinDurationMs: number
   apiBase: string
+  streamEnabled: boolean
 }

--- a/dashboard/src/utils/config.ts
+++ b/dashboard/src/utils/config.ts
@@ -29,6 +29,7 @@ export function normalizeDashboardConfig(raw: unknown): DashboardConfig {
   const freshMs =         parseConfigInt(config, "fresh_ms",         DEFAULT_DASHBOARD_CONFIG.freshMs, 0)
   const slowComponentMs = parseConfigInt(config, "slow_component_min_duration_ms", DEFAULT_DASHBOARD_CONFIG.slowComponentMinDurationMs, 1)
   const apiBase =         typeof config.api_base === "string" ? config.api_base : DEFAULT_DASHBOARD_CONFIG.apiBase
+  const streamEnabled =   typeof config.stream_enabled === "boolean" ? config.stream_enabled : DEFAULT_DASHBOARD_CONFIG.streamEnabled
 
   return {
     pollMs,
@@ -37,5 +38,6 @@ export function normalizeDashboardConfig(raw: unknown): DashboardConfig {
     freshMs,
     slowComponentMinDurationMs: slowComponentMs,
     apiBase,
+    streamEnabled,
   }
 }

--- a/dashboard/src/utils/traces.test.ts
+++ b/dashboard/src/utils/traces.test.ts
@@ -121,6 +121,19 @@ describe("isOngoing", () => {
     const trace = makeTrace({ root_span: makeSpan({ duration_ms: 42 }), tags: [{ key: "service.name", value: "hayhooks" }] })
     expect(isOngoing(trace)).toBe(false)
   })
+
+  it("uses the root running flag over a leaked child success tag", () => {
+    const trace = makeTrace({
+      root_span: makeSpan({ duration_ms: 0, running: true }),
+      tags: [{ key: "hayhooks.success", value: "true" }],
+    })
+    expect(isOngoing(trace)).toBe(true)
+  })
+
+  it("returns false when the root running flag is false", () => {
+    const trace = makeTrace({ root_span: makeSpan({ duration_ms: 0, running: false }), tags: [] })
+    expect(isOngoing(trace)).toBe(false)
+  })
 })
 
 describe("traceKind", () => {

--- a/dashboard/src/utils/traces.ts
+++ b/dashboard/src/utils/traces.ts
@@ -48,9 +48,16 @@ export function isFailed(trace: TraceSummary): boolean {
 
 export function isOngoing(trace: TraceSummary): boolean {
   if (isFailed(trace)) return false
+  const root = trace.root_span
+  // Prefer the explicit per-span running flag: a trace is ongoing iff its root
+  // span has not finished. This is robust against a finished *child* span
+  // leaking a `hayhooks.success` tag up to the trace level (which would
+  // otherwise make a still-running trace look complete).
+  if (typeof root.running === "boolean") return root.running
+  // Fallback for payloads without the flag: root still open and no success tag.
   const successTag = (trace.tags ?? []).find((tag) => tag.key === SUCCESS_TAG_KEY)
   if (successTag?.value === "true" || successTag?.value === "false") return false
-  return trace.root_span.duration_ms === 0
+  return root.duration_ms === 0
 }
 
 export function isStreaming(trace: TraceSummary): boolean {

--- a/src/hayhooks/cli/base.py
+++ b/src/hayhooks/cli/base.py
@@ -224,6 +224,7 @@ def run(  # noqa: C901, PLR0912, PLR0913, PLR0915
             reload=reload,
             factory=True,
             log_config=None,
+            timeout_graceful_shutdown=settings.graceful_shutdown_timeout,
         )
     else:
         from hayhooks.server.app import run_app

--- a/src/hayhooks/cli/mcp.py
+++ b/src/hayhooks/cli/mcp.py
@@ -68,4 +68,10 @@ def run(  # noqa: PLR0913
         settings.intercepted_loggers,
         access_log_excluded_path_prefixes=settings.access_log_excluded_path_prefixes,
     )
-    uvicorn.run(app, host=host, port=port, log_config=None)
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        log_config=None,
+        timeout_graceful_shutdown=settings.graceful_shutdown_timeout,
+    )

--- a/src/hayhooks/server/app.py
+++ b/src/hayhooks/server/app.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import sys
 from collections.abc import AsyncIterator
@@ -44,6 +45,7 @@ from hayhooks.server.utils.deploy_utils import (
     read_pipeline_files_from_dir,
     rebuild_openapi,
 )
+from hayhooks.server.utils.live_trace_stream import get_trace_stream_broadcaster
 from hayhooks.server.utils.models import PreparedPipeline
 from hayhooks.settings import APP_DESCRIPTION, APP_TITLE, StartupDeployStrategy, check_cors_settings, settings
 
@@ -242,7 +244,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     if settings.pipelines_dir:
         deploy_pipelines(app, settings.pipelines_dir)
 
-    yield
+    # Capture the running loop so synchronous span recording can wake SSE
+    # subscribers via call_soon_threadsafe.
+    broadcaster = get_trace_stream_broadcaster()
+    broadcaster.set_loop(asyncio.get_running_loop())
+    try:
+        yield
+    finally:
+        broadcaster.clear_loop()
 
 
 @lru_cache(maxsize=1)
@@ -364,6 +373,7 @@ def run_app(
         host=host or settings.host,
         port=port or settings.port,
         log_config=None,
+        timeout_graceful_shutdown=settings.graceful_shutdown_timeout,
     )
 
 

--- a/src/hayhooks/server/routers/dashboard.py
+++ b/src/hayhooks/server/routers/dashboard.py
@@ -1,8 +1,16 @@
-from fastapi import APIRouter, Query, Response
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from contextlib import suppress
+from typing import Any
+
+from fastapi import APIRouter, Query, Request, Response
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from hayhooks.server.pipelines.registry import registry
 from hayhooks.server.utils.live_trace_buffer import clear_live_traces, get_recent_traces
+from hayhooks.server.utils.live_trace_stream import get_trace_stream_broadcaster
 from hayhooks.settings import settings
 
 router = APIRouter()
@@ -24,6 +32,7 @@ class TraceSpanNode(BaseModel):
     name: str
     start_time_ms: int
     duration_ms: int
+    running: bool = Field(default=False, description="True while the span is in progress (not yet finished).")
     tags: list[TraceTag] = Field(default_factory=list)
     children: list["TraceSpanNode"] = Field(default_factory=list)
 
@@ -56,6 +65,10 @@ class DashboardUiConfigResponse(BaseModel):
     fresh_ms: int
     slow_component_min_duration_ms: int
     api_base: str = Field(description="Base URL for dashboard API endpoints")
+    stream_enabled: bool = Field(
+        default=True,
+        description="Whether the real-time SSE trace stream is available; clients fall back to polling when false.",
+    )
 
 
 @router.get(
@@ -92,7 +105,32 @@ async def config() -> DashboardUiConfigResponse:
         fresh_ms=settings.dashboard_ui_fresh_ms,
         slow_component_min_duration_ms=settings.dashboard_ui_slow_component_min_duration_ms,
         api_base=api_base,
+        stream_enabled=settings.dashboard_stream_enabled,
     )
+
+
+def read_trace_deltas(
+    *,
+    after_seq: int | None,
+    limit: int,
+    since_ms: int | None = None,
+) -> TracesResponse:
+    """
+    Read normalized traces newer than ``after_seq`` and build the response.
+
+    Shared by the polling endpoint (`/api/traces`) and the SSE stream so both
+    use identical cursor/pagination semantics. ``next_after_seq`` advances the
+    caller's cursor; ``has_more`` signals a backlog larger than ``limit``.
+    """
+    resolved_limit = min(limit, settings.dashboard_trace_max_limit)
+    traces_data = get_recent_traces(since_ms=since_ms, limit=resolved_limit + 1, after_seq=after_seq)
+    has_more = len(traces_data) > resolved_limit
+    if has_more:
+        traces_data = traces_data[:resolved_limit]
+    traces_data.sort(key=lambda trace: trace["start_time_ms"], reverse=True)
+    traces_payload = [TraceSummary.model_validate(trace) for trace in traces_data]
+    next_after_seq = max((trace.get("_cursor_seq", 0) for trace in traces_data), default=after_seq or 0)
+    return TracesResponse(traces=traces_payload, next_after_seq=next_after_seq, has_more=has_more)
 
 
 @router.get(
@@ -110,16 +148,75 @@ async def traces(
     after_seq: int | None = Query(default=None, ge=0),
 ) -> TracesResponse:
     requested_limit = settings.dashboard_trace_default_limit if limit is None else limit
-    resolved_limit = min(requested_limit, settings.dashboard_trace_max_limit)
-    traces_data = get_recent_traces(since_ms=since_ms, limit=resolved_limit + 1, after_seq=after_seq)
-    has_more = len(traces_data) > resolved_limit
-    if has_more:
-        traces_data = traces_data[:resolved_limit]
-    traces_data.sort(key=lambda trace: trace["start_time_ms"], reverse=True)
-    traces_payload = [TraceSummary.model_validate(trace) for trace in traces_data]
-    next_after_seq = max((trace.get("_cursor_seq", 0) for trace in traces_data), default=after_seq or 0)
-    response.headers["X-Hayhooks-Trace-Cursor"] = str(next_after_seq)
-    return TracesResponse(traces=traces_payload, next_after_seq=next_after_seq, has_more=has_more)
+    result = read_trace_deltas(after_seq=after_seq, limit=requested_limit, since_ms=since_ms)
+    response.headers["X-Hayhooks-Trace-Cursor"] = str(result.next_after_seq)
+    return result
+
+
+def _sse_event(event: str, data: dict[str, Any]) -> str:
+    return f"event: {event}\ndata: {json.dumps(data, separators=(',', ':'))}\n\n"
+
+
+@router.get(
+    "/api/traces/stream",
+    tags=["dashboard"],
+    operation_id="dashboard_traces_stream",
+    summary="Stream recent traces in real time (SSE)",
+    description=(
+        "Server-Sent Events stream of trace updates. Emits a `snapshot` event on connect, then `trace` "
+        "delta events as spans start/finish, with periodic keepalive comments. Payloads match `/api/traces`."
+    ),
+)
+async def traces_stream(request: Request) -> StreamingResponse:
+    raw_after_seq = request.query_params.get("after_seq")
+    initial_after_seq: int | None = None
+    if raw_after_seq is not None:
+        with suppress(ValueError):
+            parsed = int(raw_after_seq)
+            initial_after_seq = parsed if parsed >= 0 else None
+
+    broadcaster = get_trace_stream_broadcaster()
+    queue = broadcaster.subscribe()
+    heartbeat_seconds = settings.dashboard_stream_heartbeat_ms / 1000
+
+    async def event_stream() -> AsyncIterator[str]:
+        try:
+            # On connect: replay from the client's cursor if provided (reconnect),
+            # otherwise send the full current buffer. mergeTraces dedups, so a
+            # repeated snapshot on reconnect is harmless.
+            snapshot = read_trace_deltas(after_seq=initial_after_seq, limit=settings.dashboard_ui_list_cap)
+            cursor = snapshot.next_after_seq
+            yield _sse_event("snapshot", snapshot.model_dump(mode="json"))
+
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    await asyncio.wait_for(queue.get(), timeout=heartbeat_seconds)
+                except asyncio.TimeoutError:
+                    yield ": keepalive\n\n"
+                    continue
+
+                # Drain everything new since our cursor (handles bursts/backlog).
+                while True:
+                    delta = read_trace_deltas(after_seq=cursor, limit=settings.dashboard_trace_default_limit)
+                    cursor = delta.next_after_seq
+                    if delta.traces:
+                        yield _sse_event("trace", delta.model_dump(mode="json"))
+                    if not delta.has_more:
+                        break
+        finally:
+            broadcaster.unsubscribe(queue)
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )
 
 
 @router.post(

--- a/src/hayhooks/server/utils/live_trace_buffer.py
+++ b/src/hayhooks/server/utils/live_trace_buffer.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from threading import RLock
 from time import time
 from typing import Any, TypedDict
 
 from typing_extensions import NotRequired
 
+from hayhooks.server.logger import log
 from hayhooks.settings import settings
 
 _TRACE_TAG_PRIORITY = (
@@ -42,6 +43,7 @@ class TraceSpanNodeDict(TypedDict):
     name: str
     start_time_ms: int
     duration_ms: int
+    running: bool
     tags: list[TraceTagDict]
     children: list[TraceSpanNodeDict]
 
@@ -63,6 +65,7 @@ class _SpanState(TypedDict):
     name: str
     start_time_ms: int
     duration_ms: int
+    running: bool
     tags: dict[str, Any]
 
 
@@ -100,6 +103,7 @@ def _new_span_state(
         "name": operation_name,
         "start_time_ms": start_time_ms,
         "duration_ms": 0,
+        "running": True,
         "tags": tags,
     }
 
@@ -271,6 +275,7 @@ class _LiveTraceBuffer:
                 return
 
             span["duration_ms"] = max(0, duration_ms)
+            span["running"] = False
             if tags:
                 span["tags"].update(_truncate_tag_values(dict(tags)))
                 if (
@@ -309,6 +314,7 @@ class _LiveTraceBuffer:
                         "name": span["name"],
                         "start_time_ms": span["start_time_ms"],
                         "duration_ms": span["duration_ms"],
+                        "running": span["running"],
                         "tags": tags_copy,
                     }
                 trace_copies.append(
@@ -368,6 +374,7 @@ class _LiveTraceBuffer:
                 "name": span["name"],
                 "start_time_ms": span["start_time_ms"],
                 "duration_ms": span["duration_ms"],
+                "running": span["running"],
                 "tags": _collect_span_tags(span.get("tags", {})),
                 "children": [build_span_tree(child_id) for child_id in child_ids],
             }
@@ -404,6 +411,29 @@ class _LiveTraceBuffer:
 
 _TRACE_BUFFER = _LiveTraceBuffer()
 
+_change_listeners: list[Callable[[], None]] = []
+
+
+def register_change_listener(listener: Callable[[], None]) -> None:
+    """
+    Register a callback fired after any span start/finish is recorded.
+
+    Used by the SSE layer to wake streaming subscribers. Kept dependency-free
+    (no asyncio import here) so the buffer stays a plain in-memory store. The
+    callback must be cheap and non-blocking; it must never raise. Registration
+    is idempotent.
+    """
+    if listener not in _change_listeners:
+        _change_listeners.append(listener)
+
+
+def _emit_change() -> None:
+    for listener in _change_listeners:
+        try:
+            listener()
+        except Exception as exc:  # never let notification break span recording
+            log.debug("Trace change listener raised: {}", exc)
+
 
 def record_live_span_start(  # noqa: PLR0913
     *,
@@ -422,6 +452,7 @@ def record_live_span_start(  # noqa: PLR0913
         start_time_ms=start_time_ms,
         tags=tags,
     )
+    _emit_change()
 
 
 def record_live_span_finish(
@@ -438,6 +469,7 @@ def record_live_span_finish(
         completed_at_ms=int(time() * 1000),
         tags=tags,
     )
+    _emit_change()
 
 
 def get_recent_traces(

--- a/src/hayhooks/server/utils/live_trace_stream.py
+++ b/src/hayhooks/server/utils/live_trace_stream.py
@@ -1,0 +1,88 @@
+"""
+Fan-out of live trace-buffer changes to SSE subscribers.
+
+Span recording happens synchronously (often on worker threads); SSE consumers
+run on the asyncio event loop. This module bridges the two: a sync ``notify()``
+called from the recording hot path wakes each async subscriber via
+``loop.call_soon_threadsafe``.
+
+Each subscriber queue is a *coalescing wake-signal* (``maxsize=1``), so a burst
+of span events collapses into a single delta read on the consumer side. The
+payload is irrelevant — the consumer re-reads the buffer from its own cursor
+when woken.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from threading import Lock
+
+from hayhooks.server.logger import log
+from hayhooks.server.utils.live_trace_buffer import register_change_listener
+
+
+class _TraceStreamBroadcaster:
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._subscribers: set[asyncio.Queue[int]] = set()
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    def set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        with self._lock:
+            self._loop = loop
+
+    def clear_loop(self) -> None:
+        with self._lock:
+            self._loop = None
+
+    def subscribe(self) -> asyncio.Queue[int]:
+        queue: asyncio.Queue[int] = asyncio.Queue(maxsize=1)
+        with self._lock:
+            self._subscribers.add(queue)
+        return queue
+
+    def unsubscribe(self, queue: asyncio.Queue[int]) -> None:
+        with self._lock:
+            self._subscribers.discard(queue)
+
+    def subscriber_count(self) -> int:
+        with self._lock:
+            return len(self._subscribers)
+
+    def notify(self) -> None:
+        """Wake all subscribers. Safe to call from any thread; never raises."""
+        with self._lock:
+            loop = self._loop
+            subscribers = list(self._subscribers)
+        if loop is None or not subscribers:
+            return
+        for queue in subscribers:
+            # RuntimeError means the loop is closed/closing — drop the signal.
+            with suppress(RuntimeError):
+                loop.call_soon_threadsafe(self._wake, queue)
+
+    @staticmethod
+    def _wake(queue: asyncio.Queue[int]) -> None:
+        # Runs on the loop thread; coalesce by skipping when already signalled.
+        if queue.full():
+            return
+        with suppress(asyncio.QueueFull):
+            queue.put_nowait(1)
+
+
+_BROADCASTER = _TraceStreamBroadcaster()
+
+
+def get_trace_stream_broadcaster() -> _TraceStreamBroadcaster:
+    return _BROADCASTER
+
+
+def notify_trace_changed() -> None:
+    _BROADCASTER.notify()
+
+
+# Wire the buffer's change hook to our notify as soon as this module is imported
+# (it is imported when the dashboard router loads, before any traces flow).
+register_change_listener(notify_trace_changed)
+log.debug("Live trace stream broadcaster registered as buffer change listener")

--- a/src/hayhooks/settings.py
+++ b/src/hayhooks/settings.py
@@ -46,6 +46,12 @@ class AppSettings(BaseSettings):
     # Hayhooks Port
     port: int = 1416
 
+    # Max seconds to wait for in-flight connections to drain on shutdown (Ctrl-C)
+    # before they are cancelled. Bounds graceful shutdown so long-lived
+    # connections (e.g. the dashboard SSE stream) don't block server exit
+    # indefinitely. Passed to uvicorn as ``timeout_graceful_shutdown``.
+    graceful_shutdown_timeout: int = Field(default=5, ge=0, le=300)
+
     # Whether to use HTTPS when running CLI commands
     # Example: `hayhooks status`
     # NOTE: This is NOT used to specify the protocol for the uvicorn server
@@ -122,6 +128,12 @@ class AppSettings(BaseSettings):
     dashboard_ui_fetch_limit: int = Field(default=50, gt=0, le=500)
     dashboard_ui_fresh_ms: int = Field(default=6000, ge=0, le=60_000)
     dashboard_ui_slow_component_min_duration_ms: int = Field(default=1000, gt=0)
+    # Real-time trace streaming (SSE). When enabled, the dashboard receives trace
+    # updates over a Server-Sent Events stream instead of polling; polling stays
+    # as an automatic client-side fallback. Heartbeat keeps the connection alive
+    # through proxies during idle periods.
+    dashboard_stream_enabled: bool = True
+    dashboard_stream_heartbeat_ms: int = Field(default=15_000, ge=1_000, le=120_000)
     dashboard_enabled: bool = False
     dashboard_path: str = "/dashboard"
     dashboard_dist_dir: str = str(Path.cwd() / "dashboard" / "dist")

--- a/tests/test_it_dashboard.py
+++ b/tests/test_it_dashboard.py
@@ -18,6 +18,7 @@ def _sample_trace(trace_id: str, start_time_ms: int) -> dict[str, object]:
             "name": "hayhooks.pipeline.run",
             "start_time_ms": start_time_ms,
             "duration_ms": 12,
+            "running": False,
             "tags": [],
             "children": [
                 {
@@ -25,6 +26,7 @@ def _sample_trace(trace_id: str, start_time_ms: int) -> dict[str, object]:
                     "name": "hayhooks.openai.run",
                     "start_time_ms": start_time_ms + 4,
                     "duration_ms": 3,
+                    "running": False,
                     "tags": [],
                     "children": [],
                 }

--- a/tests/test_live_trace_stream.py
+++ b/tests/test_live_trace_stream.py
@@ -1,0 +1,190 @@
+import asyncio
+import json
+
+from hayhooks.server.routers.dashboard import config, traces_stream
+from hayhooks.server.utils.live_trace_buffer import (
+    clear_live_traces,
+    get_recent_traces,
+    record_live_span_finish,
+    record_live_span_start,
+)
+from hayhooks.server.utils.live_trace_stream import _TraceStreamBroadcaster, get_trace_stream_broadcaster
+from hayhooks.settings import settings
+
+
+def setup_function():
+    clear_live_traces()
+
+
+class _FakeRequest:
+    """
+    Minimal stand-in for a Starlette Request to drive the SSE handler directly.
+
+    httpx's ASGITransport buffers the whole response before returning, so it
+    cannot consume an open-ended stream — we exercise the handler's
+    StreamingResponse.body_iterator instead.
+    """
+
+    def __init__(self, after_seq: int | None = None) -> None:
+        self.query_params: dict[str, str] = {} if after_seq is None else {"after_seq": str(after_seq)}
+
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+def _frame_data(frame: str) -> str:
+    """Extract the JSON payload from an SSE event frame's `data:` line(s)."""
+    return "".join(line[len("data:") :].lstrip() for line in frame.splitlines() if line.startswith("data:"))
+
+
+async def _next_sse_event(body_iterator, timeout: float = 3.0) -> str:
+    """Pull the next named SSE event frame, skipping keepalive comments."""
+
+    async def run() -> str:
+        async for frame in body_iterator:
+            if frame.startswith(":"):  # keepalive comment
+                continue
+            return frame
+        msg = "stream ended before an event was received"
+        raise AssertionError(msg)
+
+    return await asyncio.wait_for(run(), timeout=timeout)
+
+
+# --- Broadcaster unit tests -------------------------------------------------
+
+
+def test_notify_without_loop_is_noop():
+    broadcaster = _TraceStreamBroadcaster()
+    # No loop set and no subscribers: must not raise.
+    broadcaster.notify()
+
+
+async def test_subscribe_unsubscribe_tracks_count():
+    broadcaster = _TraceStreamBroadcaster()
+    broadcaster.set_loop(asyncio.get_running_loop())
+    assert broadcaster.subscriber_count() == 0
+    queue = broadcaster.subscribe()
+    assert broadcaster.subscriber_count() == 1
+    broadcaster.unsubscribe(queue)
+    assert broadcaster.subscriber_count() == 0
+
+
+async def test_notify_wakes_subscriber_and_coalesces():
+    broadcaster = _TraceStreamBroadcaster()
+    broadcaster.set_loop(asyncio.get_running_loop())
+    queue = broadcaster.subscribe()
+    try:
+        broadcaster.notify()
+        broadcaster.notify()
+        broadcaster.notify()
+        await asyncio.sleep(0)  # let call_soon_threadsafe callbacks run
+        # Coalescing: maxsize=1 means three rapid notifies collapse to one signal.
+        assert queue.qsize() == 1
+    finally:
+        broadcaster.unsubscribe(queue)
+
+
+async def test_record_span_wakes_subscriber_via_buffer_hook():
+    broadcaster = get_trace_stream_broadcaster()
+    broadcaster.set_loop(asyncio.get_running_loop())
+    queue = broadcaster.subscribe()
+    try:
+        record_live_span_start(
+            trace_id="t1",
+            span_id="s1",
+            parent_span_id=None,
+            operation_name="hayhooks.pipeline.run",
+            start_time_ms=1000,
+        )
+        await asyncio.sleep(0)
+        assert not queue.empty()
+    finally:
+        broadcaster.unsubscribe(queue)
+        broadcaster.clear_loop()
+
+
+# --- SSE endpoint tests (drive the StreamingResponse directly) --------------
+
+
+async def test_stream_emits_snapshot_then_trace_delta():
+    broadcaster = get_trace_stream_broadcaster()
+    broadcaster.set_loop(asyncio.get_running_loop())
+    try:
+        response = await traces_stream(_FakeRequest())
+        body = response.body_iterator
+        try:
+            snapshot = await _next_sse_event(body)
+            assert snapshot.startswith("event: snapshot")
+            assert json.loads(_frame_data(snapshot))["traces"] == []  # buffer cleared in setup
+
+            record_live_span_start(
+                trace_id="t1",
+                span_id="s1",
+                parent_span_id=None,
+                operation_name="hayhooks.pipeline.run",
+                start_time_ms=1000,
+                tags={"hayhooks.pipeline.name": "demo"},
+            )
+            record_live_span_finish(trace_id="t1", span_id="s1", duration_ms=5)
+
+            trace_frame = await _next_sse_event(body)
+            assert trace_frame.startswith("event: trace")
+            payload = json.loads(_frame_data(trace_frame))
+            assert "t1" in [t["trace_id"] for t in payload["traces"]]
+        finally:
+            await body.aclose()
+    finally:
+        broadcaster.clear_loop()
+
+
+async def test_stream_unsubscribes_on_close():
+    broadcaster = get_trace_stream_broadcaster()
+    broadcaster.set_loop(asyncio.get_running_loop())
+    baseline = broadcaster.subscriber_count()
+    try:
+        response = await traces_stream(_FakeRequest())
+        body = response.body_iterator
+        await _next_sse_event(body)  # snapshot — starts the generator; subscription active
+        assert broadcaster.subscriber_count() == baseline + 1
+        await body.aclose()  # generator's finally runs unsubscribe
+        assert broadcaster.subscriber_count() == baseline
+    finally:
+        broadcaster.clear_loop()
+
+
+def test_span_running_flag_reflects_finish_state():
+    record_live_span_start(
+        trace_id="t1",
+        span_id="root",
+        parent_span_id=None,
+        operation_name="hayhooks.pipeline.run",
+        start_time_ms=1000,
+    )
+    record_live_span_start(
+        trace_id="t1",
+        span_id="child",
+        parent_span_id="root",
+        operation_name="haystack.component.run",
+        start_time_ms=1002,
+    )
+    # child still running, root still running
+    trace = get_recent_traces(since_ms=None, limit=10)[0]
+    assert trace["root_span"]["running"] is True
+    assert trace["root_span"]["children"][0]["running"] is True
+
+    record_live_span_finish(trace_id="t1", span_id="child", duration_ms=3)
+    trace = get_recent_traces(since_ms=None, limit=10)[0]
+    assert trace["root_span"]["running"] is True  # root still open
+    assert trace["root_span"]["children"][0]["running"] is False  # child finished
+
+    record_live_span_finish(trace_id="t1", span_id="root", duration_ms=9)
+    trace = get_recent_traces(since_ms=None, limit=10)[0]
+    assert trace["root_span"]["running"] is False
+    assert trace["root_span"]["children"][0]["running"] is False
+
+
+async def test_config_exposes_stream_enabled(monkeypatch):
+    monkeypatch.setattr(settings, "dashboard_stream_enabled", True, raising=False)
+    result = await config()
+    assert result.stream_enabled is True


### PR DESCRIPTION
This adds:

- live trace streaming over SSE (replaces polling)
- a high-contrast near-black theme

**Live tracing**
- New `GET /dashboard/api/traces/stream`; dashboard uses `EventSource` instead of polling,
  with REST `/api/traces` as initial load + automatic fallback.
- Thread-safe→async broadcaster bridges sync span recording to SSE (coalesced wakes, reuses
  the existing cursor/normalization path). Gated by `dashboard_stream_enabled`.

**`ongoing` UX**
- Per-span `running` flag so spans appear/pulse live; `isOngoing` now uses the root span's
  running state (no more leaked `hayhooks.success` tag marking running traces "done").
- Animated border-beam on ongoing cards; latest trace auto-expands, older ones collapse.

**New theme**
- Vivid near-black dark theme (default), Haystack palette, borderless span rows; fixed
  faux-bold text by loading real Inter 400/500/600.
